### PR TITLE
72 app settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "class-variance-authority": "^0.7.0",
     "csv-parse": "^5.5.6",
     "date-fns": "^3.6.0",
+    "electron-first-run": "^3.0.0",
+    "electron-settings": "^4.0.4",
     "electron-updater": "^6.2.1",
     "focus-trap-react": "^10.2.3",
     "object-hash": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,12 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      electron-first-run:
+        specifier: ^3.0.0
+        version: 3.0.0
+      electron-settings:
+        specifier: ^4.0.4
+        version: 4.0.4(electron@28.3.3)
       electron-updater:
         specifier: ^6.2.1
         version: 6.2.1
@@ -1713,8 +1719,16 @@ packages:
   electron-devtools-installer@3.2.0:
     resolution: {integrity: sha512-t3UczsYugm4OAbqvdImMCImIMVdFzJAHgbwHpkl5jmfu1izVgUcP/mnrPqJIpEeCK1uZGpt+yHgWEN+9EwoYhQ==}
 
+  electron-first-run@3.0.0:
+    resolution: {integrity: sha512-+GV8XX3vtVE9r+yuASNxsXm3FErdUnJAle4nvzBOPlEKT4Nuj044s3hgXkZh3aMupyMMYrNT+y4HVDUTOUABeg==}
+
   electron-publish@24.13.1:
     resolution: {integrity: sha512-2ZgdEqJ8e9D17Hwp5LEq5mLQPjqU3lv/IALvgp+4W8VeNhryfGhYEQC/PgDPMrnWUp+l60Ou5SJLsu+k4mhQ8A==}
+
+  electron-settings@4.0.4:
+    resolution: {integrity: sha512-yR6ByH3hHqDgbcQ9y5foA2Pr2fSMIggFDMsHe71z1Og6myw7vxMlrkIzenmmrmZHeFLlvQyt7+gTZCH8BywHBw==}
+    peerDependencies:
+      electron: '>= 2'
 
   electron-to-chromium@1.5.7:
     resolution: {integrity: sha512-6FTNWIWMxMy/ZY6799nBlPtF1DFDQ6VQJ7yyDP27SJNt5lwtQ5ufqVvHylb3fdQefvRcgA3fKcFMJi9OLwBRNw==}
@@ -2428,6 +2442,9 @@ packages:
     resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
     engines: {node: '>= 0.4'}
 
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -2647,6 +2664,10 @@ packages:
 
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
 
   make-fetch-happen@9.1.0:
     resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
@@ -3588,6 +3609,9 @@ packages:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
 
+  typedarray-to-buffer@3.1.5:
+    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+
   typeorm@0.3.20:
     resolution: {integrity: sha512-sJ0T08dV5eoZroaq9uPKBoNcGslHBR4E4y+EBHs//SiGbblGe7IeduP/IH4ddCcj0qp3PHwDwGnuvqEAnKlq/Q==}
     engines: {node: '>=16.13.0'}
@@ -3794,6 +3818,9 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@3.0.3:
+    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
@@ -4886,7 +4913,7 @@ snapshots:
 
   app-builder-bin@4.0.0: {}
 
-  app-builder-lib@24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
+  app-builder-lib@24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.2.1
@@ -4900,7 +4927,7 @@ snapshots:
       builder-util-runtime: 9.2.4
       chromium-pickle-js: 0.2.0
       debug: 4.3.6
-      dmg-builder: 24.13.3(electron-builder-squirrel-windows@24.13.3)
+      dmg-builder: 24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       ejs: 3.1.10
       electron-builder-squirrel-windows: 24.13.3(dmg-builder@24.13.3)
       electron-publish: 24.13.1
@@ -5540,9 +5567,9 @@ snapshots:
 
   dlv@1.1.3: {}
 
-  dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
+  dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       builder-util: 24.13.1
       builder-util-runtime: 9.2.4
       fs-extra: 10.1.0
@@ -5602,7 +5629,7 @@ snapshots:
 
   electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       archiver: 5.3.2
       builder-util: 24.13.1
       fs-extra: 10.1.0
@@ -5612,11 +5639,11 @@ snapshots:
 
   electron-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       builder-util: 24.13.1
       builder-util-runtime: 9.2.4
       chalk: 4.1.2
-      dmg-builder: 24.13.3(electron-builder-squirrel-windows@24.13.3)
+      dmg-builder: 24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       fs-extra: 10.1.0
       is-ci: 3.0.1
       lazy-val: 1.0.5
@@ -5634,6 +5661,10 @@ snapshots:
       tslib: 2.6.3
       unzip-crx-3: 0.2.0
 
+  electron-first-run@3.0.0:
+    dependencies:
+      make-dir: 3.1.0
+
   electron-publish@24.13.1:
     dependencies:
       '@types/fs-extra': 9.0.13
@@ -5645,6 +5676,13 @@ snapshots:
       mime: 2.6.0
     transitivePeerDependencies:
       - supports-color
+
+  electron-settings@4.0.4(electron@28.3.3):
+    dependencies:
+      electron: 28.3.3
+      lodash: 4.17.21
+      mkdirp: 1.0.4
+      write-file-atomic: 3.0.3
 
   electron-to-chromium@1.5.7: {}
 
@@ -6568,6 +6606,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.15
 
+  is-typedarray@1.0.0: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.0.2:
@@ -6764,6 +6804,10 @@ snapshots:
   magic-string@0.30.11:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
 
   make-fetch-happen@9.1.0:
     dependencies:
@@ -7451,8 +7495,7 @@ snapshots:
       get-intrinsic: 1.2.4
       object-inspect: 1.13.2
 
-  signal-exit@3.0.7:
-    optional: true
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
@@ -7824,6 +7867,10 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
+  typedarray-to-buffer@3.1.5:
+    dependencies:
+      is-typedarray: 1.0.0
+
   typeorm@0.3.20(better-sqlite3@11.1.2)(sqlite3@5.1.7):
     dependencies:
       '@sqltools/formatter': 1.2.5
@@ -8002,6 +8049,13 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
+
+  write-file-atomic@3.0.3:
+    dependencies:
+      imurmurhash: 0.1.4
+      is-typedarray: 1.0.0
+      signal-exit: 3.0.7
+      typedarray-to-buffer: 3.1.5
 
   xmlbuilder@15.1.1: {}
 

--- a/src/main/database/athlete-db.ts
+++ b/src/main/database/athlete-db.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { parse } from "csv-parse";
+import settings from "electron-settings";
 import { getDatabaseConnection } from "./connect-db";
-import { data } from "../../preload/data";
 import { DatabaseStatus } from "../../shared/enums";
 import { AthleteDB, DNXRecord } from "../../shared/models";
 import { DatabaseResponse } from "../../shared/types";
@@ -116,12 +116,14 @@ export function GetTotalDNF(): number {
 }
 
 export function GetStationDNF(): number {
-  const count = GetCountFromAthletesWithWhere("dnf", `dnfStation == '${data.station.name}'`);
+  const stationName = settings.getSync("station.name") as string;
+  const count = GetCountFromAthletesWithWhere("dnf", `dnfStation == '${stationName}'`);
   return count[0] == null ? invalidResult : count[0];
 }
 
 export function GetPreviousDNF(): number {
   const db = getDatabaseConnection();
+  const stationId = settings.getSync("station.id") as number;
   let queryResult;
 
   try {
@@ -140,7 +142,7 @@ export function GetPreviousDNF(): number {
 
   for (const athlete of dnfList) {
     const id = Number(Array.from(athlete.dnfStation as string)[0]);
-    if (id < data.station.id) previousDNF.push(athlete);
+    if (id < stationId) previousDNF.push(athlete);
   }
 
   return previousDNF.length == null ? invalidResult : previousDNF.length;

--- a/src/main/database/stations-db.ts
+++ b/src/main/database/stations-db.ts
@@ -1,12 +1,9 @@
+import settings from "electron-settings";
 import { DatabaseStatus, EntryMode } from "$shared/enums";
 import { DatabaseResponse } from "$shared/types";
 import { clearStationsTable, getDatabaseConnection } from "./connect-db";
-import { data } from "../../preload/data";
 import { Operator, Station, StationDB } from "../../shared/models";
 import { selectStationsFile } from "../lib/file-dialogs";
-
-//TODO: we will need to set myStation, ought to create a settings table instaed of these hard-coded values
-//import { data } from "../../preload/data";
 
 export async function LoadStations() {
   //const devStationData = require("$resources/config/stations.json");
@@ -19,7 +16,7 @@ export async function LoadStations() {
     if (GetStations().length > 0) {
       clearStationsTable();
     }
-    if (index == "event") data.event.name = stationData.event[0];
+    if (index == "event") await settings.set("event.name", stationData.event[0]);
 
     if (index == "stations") {
       for (const key in stationData.stations) {

--- a/src/main/database/timingRecords-db.ts
+++ b/src/main/database/timingRecords-db.ts
@@ -1,6 +1,6 @@
+import settings from "electron-settings";
 import { DatabaseResponse } from "$shared/types";
 import { getDatabaseConnection } from "./connect-db";
-import { data } from "../../preload/data";
 import { DatabaseStatus } from "../../shared/enums";
 import { RunnerDB } from "../../shared/models";
 
@@ -109,6 +109,7 @@ function updateTimeRecord(
   merge: boolean
 ): DatabaseResponse {
   const db = getDatabaseConnection();
+  const stationId = settings.getSync("station.id") as number;
   let queryString = "";
 
   // scrub any string values coming from the UI
@@ -125,7 +126,7 @@ function updateTimeRecord(
   }
 
   //build the time record
-  const stationID = data.station.id;
+  const stationID = stationId;
   const timeInISO = record.timeIn == null ? null : record.timeIn.toISOString();
   const timeOutISO = record.timeOut == null ? null : record.timeOut.toISOString();
   const modifiedISO = record.timeModified == null ? null : record.timeModified.toISOString();
@@ -165,8 +166,9 @@ function updateTimeRecord(
 
 function insertTimeRecord(record: RunnerDB): DatabaseResponse {
   const db = getDatabaseConnection();
+  const stationId = settings.getSync("station.id") as number;
 
-  const stationID = data.station.id;
+  const stationID = stationId;
   const timeInISO = record.timeIn == null ? null : record.timeIn.toISOString();
   const timeOutISO = record.timeOut == null ? null : record.timeOut.toISOString();
   const modifiedISO = record.timeModified == null ? null : record.timeModified.toISOString();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import { initializeIpcHandlers } from "./ipc/init-ipc";
 import { installDevTools, openDevToolsOnDomReady } from "./lib/devtools";
 import { initUserDirectories } from "./lib/file-dialogs";
 import { initStatEngine } from "./lib/stat-engine";
+import { initializeDefaultAppSettings } from "../preload/data";
 
 function createWindow(): BrowserWindow {
   const mainWindow = new BrowserWindow({
@@ -47,6 +48,7 @@ app.on("ready", async () => {
 
   await installDevTools();
 
+  initializeDefaultAppSettings();
   createDatabaseConnection();
   initializeIpcHandlers();
   initUserDirectories();

--- a/src/main/ipc/settings-ipc.ts
+++ b/src/main/ipc/settings-ipc.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-default-export */
 import { ipcMain } from "electron";
+import settings from "electron-settings";
 import * as dbAthlete from "../database/athlete-db";
 import { Handler } from "../types";
 
@@ -25,7 +26,13 @@ const runnerLookup: Handler = () => {
   return message;
 };
 
+// TODO: need to figure out how to provide renderer with app settings.
+const getAppSettings: Handler = () => {
+  return settings;
+};
+
 export const initSettingsHandlers = () => {
+  ipcMain.handle("app-settings", getAppSettings);
   ipcMain.handle("runner-lookup", runnerLookup);
 };
 

--- a/src/main/lib/file-dialogs.ts
+++ b/src/main/lib/file-dialogs.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { app, dialog } from "electron";
-import { data } from "../../preload/data";
+import settings from "electron-settings";
 
 export const selectStationsFile = async (): Promise<string[]> => {
   const dialogConfig = {
@@ -84,7 +84,8 @@ export const loadFromCSV = async (title: string): Promise<string[]> => {
 };
 
 export const saveRunnersToCSV = async (): Promise<string> => {
-  const formattedStationId = data.station.id.toLocaleString("en-US", {
+  const stationId = settings.getSync("station.id") as number;
+  const formattedStationId = stationId.toLocaleString("en-US", {
     minimumIntegerDigits: 2,
     useGrouping: false
   });

--- a/src/preload/data.ts
+++ b/src/preload/data.ts
@@ -1,15 +1,31 @@
+import settings from "electron-settings";
 import { EntryMode } from "../shared/enums";
 
 export const data = {
   targetLanguage: "eng",
-  // temp for development
-  event: {
-    name: "ultra-marathon-2024"
-  },
-  station: {
-    name: "5-temple-fork",
-    id: 5,
-    entryMode: EntryMode.Normal
-  },
-  incrementalIndex: 1
+};
+
+export const initializeDefaultAppSettings = () => {
+  settings.configure({
+    atomicSave: true,
+    fileName: "settings.json",
+    numSpaces: 2,
+    prettify: true
+  });
+
+  const firstRun = require("electron-first-run");
+  if (!firstRun()) return;
+
+  settings.set({
+    targetLanguage: "eng",
+    event: {
+      name: "ultra-marathon-2024"
+    },
+    station: {
+      name: "5-temple-fork",
+      id: 5,
+      entryMode: EntryMode.Normal
+    },
+    incrementalFileIndex: 1
+  });
 };

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -6,10 +6,6 @@ declare global {
     api: unknown;
     data: {
       targetLanguage: string;
-      station: {
-        id: number;
-        name: string;
-      };
     };
   }
 }

--- a/src/renderer/src/features/DataGrid/hooks/useSortState.tsx
+++ b/src/renderer/src/features/DataGrid/hooks/useSortState.tsx
@@ -1,7 +1,7 @@
-import { useCallback, } from "react";
+import { useCallback } from "react";
 import objectHash from "object-hash";
 import { ColumnDef } from "../types";
-import {  useSessionStorage } from "@uidotdev/usehooks";
+import { useSessionStorage } from "@uidotdev/usehooks";
 
 export type InitialSortState<T extends object> = Partial<SortState<T>>;
 
@@ -21,7 +21,10 @@ export function useSortState<T extends object>({ initial, columns }: Props<T>) {
   const hash = objectHash(columns.map((column) => column.field));
 
   const [field, setField] = useSessionStorage(`sort-field-${hash}`, initial?.field ?? null);
-  const [ascending, setAscending] = useSessionStorage(`sort-ascending-${hash}`, initial?.ascending ?? true);
+  const [ascending, setAscending] = useSessionStorage(
+    `sort-ascending-${hash}`,
+    initial?.ascending ?? true
+  );
 
   const setSort = (newField: keyof T) => {
     if (field === newField) {

--- a/src/renderer/src/hooks/data/useTiming.tsx
+++ b/src/renderer/src/hooks/data/useTiming.tsx
@@ -1,12 +1,12 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { RunnerDB } from "$shared/models";
-import { useIpcRenderer } from "../useIpcRenderer";
 import { Runner } from "./useRunnerData";
+import { useIpcRenderer } from "../useIpcRenderer";
 
 const runnerToRunnerDB = (runner: Runner): RunnerDB => ({
   index: runner.id,
   bibId: runner.runner,
-  stationId: window.data.station.id,
+  stationId: -1, // will be set by the backend
   timeIn: runner.in?.toString() == "Invalid Date" ? null : runner.in,
   timeOut: runner.out?.toString() == "Invalid Date" ? null : runner.out,
   timeModified: new Date(),


### PR DESCRIPTION
### Changelog

#### Features
Added app settings management and persistence to file to enable tracking the file export index between sessions, stations settings, and more.  Cross platform.  Default settings file is located in user's application data directory per the environment.  
e.g. Windows:  `AppData\Roaming\ultra-tracker\settings.json`

#### Packages
Added two packages to detect first run on all environments and manage app settings persistence.
"electron-first-run": "^3.0.0"
"electron-settings": "^4.0.4"

Run `pnpm install` and `pnpm rebuild` before building.