### PR TITLE
refactor: timing records are marked sent, and unsent if export fails

### DIFF
--- a/src/main/database/timingRecords-db.ts
+++ b/src/main/database/timingRecords-db.ts
@@ -269,11 +269,11 @@ function insertTimeRecord(record: TypedRunnerDB): DatabaseResponse {
   return [DatabaseStatus.Created, message];
 }
 
-export function markTimeRecordAsSent(bibId: number) {
+export function markTimeRecordAsSent(bibId: number, value: boolean) {
   const db = getDatabaseConnection();
 
   try {
-    db.prepare(`UPDATE StaEvents SET sent = ? WHERE "bibId" = ?`).run(Number(true), bibId);
+    db.prepare(`UPDATE StaEvents SET sent = ? WHERE "bibId" = ?`).run(value, bibId);
   } catch (e) {
     if (e instanceof Error) {
       console.error(e.message);


### PR DESCRIPTION
### Changelog
#### Fixes
* timing records are marked sent before the incremental output is generated
* records are marked unsent if export fails