### PR TITLE
DNF Frontend

### DIFF
--- a/src/main/database/runners-db.ts
+++ b/src/main/database/runners-db.ts
@@ -3,7 +3,7 @@ import { parse } from "csv-parse";
 import appSettings from "electron-settings";
 import { formatDate } from "$renderer/lib/datetimes";
 import { DatabaseStatus, RecordStatus } from "$shared/enums";
-import { RunnerCSV, RunnerDB, RunnerAthleteDB } from "$shared/models";
+import { RunnerAthleteDB, RunnerCSV, RunnerDB } from "$shared/models";
 import { DatabaseResponse } from "$shared/types";
 import { getDatabaseConnection } from "./connect-db";
 import { getColumnNamesFromTable } from "./tables-db";
@@ -145,7 +145,7 @@ export function readRunnersTable<T>(
 
   const statement = includeDNF
     ? `SELECT StaEvents.*, Athletes.dnf, Athletes.dnfType
-       FROM "StaEvents" LEFT JOIN "Athletes" 
+       FROM "StaEvents" LEFT JOIN "Athletes"
        ON StaEvents.bibId = Athletes.bibId`
     : `SELECT * FROM StaEvents`;
 

--- a/src/main/ipc/runnerform-ipc.ts
+++ b/src/main/ipc/runnerform-ipc.ts
@@ -1,13 +1,20 @@
 import { ipcMain } from "electron";
 import { DatabaseResponse } from "$shared/types";
-import { RunnerDB } from "../../shared/models";
+import { RunnerDB, RunnerDBWithDNF } from "../../shared/models";
 import * as dbRunners from "../database/runners-db";
 import * as dbTimings from "../database/timingRecords-db";
 import * as stats from "../lib/stat-engine";
 import { Handler } from "../types";
 
-const getRunnersTable: Handler<DatabaseResponse<RunnerDB[]>> = () => {
-  const dataset = dbRunners.readRunnersTable();
+interface GetRunnersTableOptions {
+  includeDNF: boolean;
+}
+
+const getRunnersTable: Handler<
+  GetRunnersTableOptions,
+  DatabaseResponse<RunnerDBWithDNF[] | RunnerDB[]>
+> = (_, options) => {
+  const dataset = dbRunners.readRunnersTable(options);
   return dataset;
 };
 

--- a/src/renderer/src/components/Tag.tsx
+++ b/src/renderer/src/components/Tag.tsx
@@ -1,0 +1,38 @@
+import { MouseEventHandler, ReactNode } from "react";
+import { VariantProps } from "class-variance-authority";
+import { classed } from "~/lib/classed";
+
+type TagVariants = VariantProps<typeof TagWrapper>;
+
+// TODO: Support icons in tag component
+interface TagProps {
+  color?: TagVariants["color"];
+  children: ReactNode;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+}
+
+const TagWrapper = classed.button(
+  "px-2 text-sm font-medium uppercase rounded-3xl border align-center",
+  {
+    variants: {
+      color: {
+        turquoise: "bg-[#175151] text-[#00FFF0] border-[#00FFF0]",
+        purple: "bg-[#572C7B] text-[#B8B8FF] border-[#B8B8FF]",
+        red: "bg-[#672023] text-[#FFA8A8] border-[#FFA8A8]"
+      }
+    },
+    defaultVariants: {
+      color: "turquoise"
+    }
+  }
+);
+
+export function Tag(props: TagProps) {
+  if (props.children == null) return null;
+
+  return (
+    <TagWrapper disabled={!props.onClick} color={props.color} onClick={props.onClick}>
+      {props.children}
+    </TagWrapper>
+  );
+}

--- a/src/renderer/src/features/DataGrid/Cell.tsx
+++ b/src/renderer/src/features/DataGrid/Cell.tsx
@@ -1,0 +1,47 @@
+import { useId } from "react";
+import { Tooltip } from "primereact/tooltip";
+import { usePortalRoot } from "~/hooks/dom/usePortalRoot";
+import { useTruncated } from "~/hooks/dom/useTruncated";
+import { classed } from "~/lib/classed";
+
+export const CellWrapper = classed.td(
+  "overflow-hidden py-1 px-4 h-full text-sm font-medium text-end truncate",
+  {
+    variants: {
+      align: {
+        right: "text-right",
+        left: "text-left"
+      }
+    }
+  }
+);
+
+interface CellProps {
+  children: React.ReactNode;
+  align: "left" | "right";
+}
+
+export function Cell(props: CellProps) {
+  const portalRoot = usePortalRoot();
+
+  const rawId = useId();
+  const cellId = `cell-${rawId.replace(/:/g, "")}`;
+
+  const [cellRef, truncated] = useTruncated<HTMLTableCellElement>(props.children);
+
+  return (
+    <CellWrapper align={props.align} ref={cellRef} className={cellId}>
+      {props.children}
+      {truncated && (
+        <Tooltip
+          position="top"
+          target={`.${cellId}`}
+          appendTo={portalRoot?.current}
+          pt={{ text: { className: "text-sm" } }}
+        >
+          {props.children}
+        </Tooltip>
+      )}
+    </CellWrapper>
+  );
+}

--- a/src/renderer/src/features/DataGrid/DataGrid.tsx
+++ b/src/renderer/src/features/DataGrid/DataGrid.tsx
@@ -19,7 +19,7 @@ interface Props<T extends object> {
   showFooter?: boolean;
 }
 
-const Table = classed.table("overflow-auto w-full font-display text-on-component");
+const Table = classed.table("overflow-auto w-full table-fixed font-display text-on-component");
 
 export function DataGrid<T extends object>(props: Props<T>) {
   const parentRef = useRef<HTMLDivElement>(null);

--- a/src/renderer/src/features/DataGrid/DataGrid.tsx
+++ b/src/renderer/src/features/DataGrid/DataGrid.tsx
@@ -7,13 +7,19 @@ import { InitialSortState, useSortState } from "./hooks/useSortState";
 import { TableContent } from "./TableContent";
 import { ColumnDef } from "./types";
 
+interface GridClassNames {
+  root: string;
+  table: string;
+  header: string;
+  // NOTE: Can add more as needed
+}
+
 interface Props<T extends object> {
   data: T[];
   columns: ColumnDef<T>;
   initialSort?: InitialSortState<T>;
   actionButtons?: (row: T) => ReactNode;
-  className?: string;
-  headerClassName?: string;
+  classNames?: Partial<GridClassNames>;
   getKey?: (row: T) => string | number;
   overscan?: number;
   showFooter?: boolean;
@@ -54,15 +60,19 @@ export function DataGrid<T extends object>(props: Props<T>) {
         setSortField={handleSetSortField}
         sortState={sortState}
         actionButtons={props.actionButtons}
-        className={props.headerClassName}
+        className={props.classNames?.header}
       />
     );
   };
 
   return (
-    <div ref={parentRef} className="overflow-y-auto overflow-x-hidden" style={{ height }}>
+    <div
+      ref={parentRef}
+      className={`overflow-y-auto overflow-x-hidden ${props.classNames?.root}`}
+      style={{ height }}
+    >
       <div>
-        <Table className={props.className}>
+        <Table className={props.classNames?.table}>
           {getSection("header")}
           <TableContent<T>
             rowVirtualizer={rowVirtualizer}

--- a/src/renderer/src/features/DataGrid/TableContent.tsx
+++ b/src/renderer/src/features/DataGrid/TableContent.tsx
@@ -1,19 +1,10 @@
 import { ReactNode } from "react";
 import { Virtualizer } from "@tanstack/react-virtual";
-import { classed } from "~/lib/classed";
+import { Cell, CellWrapper } from "./Cell";
 import { useKeyFn } from "./hooks/useKeyFn";
 import { useVirtualPadding } from "./hooks/useVirtualPadding";
 import { Row } from "./Row";
 import { Column } from "./types";
-
-const Cell = classed.td("py-1 px-4 h-full text-sm font-medium text-end", {
-  variants: {
-    align: {
-      right: "text-right",
-      left: "text-left"
-    }
-  }
-});
 
 interface Props<T extends object> {
   data: T[];
@@ -57,9 +48,9 @@ export function TableContent<T extends object>(props: Props<T>) {
             </Cell>
           ))}
           {props.actionButtons && (
-            <Cell align="right" className="p-0 opacity-0 group-hover:opacity-100 h-inherit">
+            <CellWrapper align="right" className="p-0 opacity-0 group-hover:opacity-100 h-inherit">
               {props.actionButtons(props.data[row.index])}
-            </Cell>
+            </CellWrapper>
           )}
         </Row>
       ))}

--- a/src/renderer/src/features/LogsPage/LogsPage.tsx
+++ b/src/renderer/src/features/LogsPage/LogsPage.tsx
@@ -9,29 +9,35 @@ export function LogsPage() {
   const columns: ColumnDef<EventLogRec> = [
     {
       field: "bibId",
-      name: "Bib#"
+      name: "Bib",
+      width: "7%"
     },
     {
       field: "stationId",
-      name: "Station"
+      name: "Station",
+      width: "15%"
     },
     {
       field: "timeIn",
       name: "Time In",
-      render: (value) => formatDate(value)
+      render: formatDate,
+      width: "13%"
     },
     {
       field: "timeOut",
       name: "Time Out",
-      render: (value) => formatDate(value)
+      render: formatDate,
+      width: "13%"
     },
     {
       field: "timeModified",
       name: "Logged At",
-      render: (value) => formatDate(value)
+      render: formatDate,
+      width: "13%"
     },
     {
-      field: "comments"
+      field: "comments",
+      sortable: false
     }
   ];
 
@@ -39,7 +45,7 @@ export function LogsPage() {
     <DataGrid
       data={data ?? []}
       columns={columns}
-      getKey={({ timeModified }) => timeModified?.toISOString() ?? ""}
+      getKey={({ index }) => index}
       initialSort={{ field: "timeModified", ascending: false }}
     />
   );

--- a/src/renderer/src/features/RunnerEntry/EditRunner.tsx
+++ b/src/renderer/src/features/RunnerEntry/EditRunner.tsx
@@ -4,14 +4,14 @@ import EditIcon from "~/assets/icons/edit.svg?react";
 import { Button, Drawer, Modal, Select, Stack, TextInput } from "~/components";
 import { DatePicker } from "~/components/DatePicker";
 import { useAthlete } from "~/hooks/data/useAthlete";
-import { RunnerWithSequence } from "~/hooks/data/useRunnerData";
+import { RunnerEx } from "~/hooks/data/useRunnerData";
 import { useDeleteTiming, useEditTiming } from "~/hooks/data/useTiming";
 import { useSelectRunnerForm } from "./hooks/useSelectRunnerForm";
 import { useToasts } from "../Toasts/useToasts";
 
 interface Props {
-  runner: RunnerWithSequence;
-  runners: RunnerWithSequence[];
+  runner: RunnerEx;
+  runners: RunnerEx[];
 }
 
 const getErrorMessage = (error: FieldError): string => {

--- a/src/renderer/src/features/RunnerEntry/EditRunner.tsx
+++ b/src/renderer/src/features/RunnerEntry/EditRunner.tsx
@@ -6,6 +6,7 @@ import { DatePicker } from "~/components/DatePicker";
 import { useAthlete } from "~/hooks/data/useAthlete";
 import { RunnerEx } from "~/hooks/data/useRunnerData";
 import { useDeleteTiming, useEditTiming } from "~/hooks/data/useTiming";
+import { DNFType } from "$shared/enums";
 import { useSelectRunnerForm } from "./hooks/useSelectRunnerForm";
 import { useToasts } from "../Toasts/useToasts";
 
@@ -64,9 +65,6 @@ export function EditRunner(props: Props) {
   };
 
   const { data: athlete } = useAthlete(form.watch("runner"), isOpen);
-
-  // Temporary state for DNF
-  const [dnf, setDnf] = useState<string | null>(null);
 
   return (
     <>
@@ -170,11 +168,13 @@ export function EditRunner(props: Props) {
                   showSeconds
                 />
                 <Select
+                  onChange={(value) => {
+                    form.setValue("dnfType", value ? (value as DNFType) : DNFType.None);
+                  }}
                   className="w-72 grow-0"
                   label="DNF"
-                  value={dnf}
-                  onChange={(value) => setDnf(value)}
-                  options={["Medical", "Withdrew", "Time", "None"]}
+                  value={form.watch("dnfType")}
+                  options={["medical", "withdrew", "time", "none"]}
                   placeholder="DNF"
                 />
               </Stack>

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -62,13 +62,14 @@ export function RunnerEntry() {
       name: "DNF",
       render: renderDNFTag,
       sortFn: sortDNF,
-      width: "10%"
+      width: "12%"
     },
     {
       field: "note",
       name: "Notes",
       sortable: false,
-      width: "30%"
+      width: "30%",
+      render: (note) => note || ""
     }
   ];
 

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -23,6 +23,12 @@ const renderDNFTag = (dnfType?: DNFType) => {
   }
 };
 
+const sortDNF = (a: RunnerEx, b: RunnerEx) => {
+  if (a.dnfType == DNFType.None) return -1;
+  if (b.dnfType == DNFType.None) return 1;
+  return a.dnfType.localeCompare(b.dnfType);
+};
+
 export function RunnerEntry() {
   const { data: runnerData } = useRunnerData();
 
@@ -30,27 +36,33 @@ export function RunnerEntry() {
     {
       field: "sequence",
       name: "Seq",
-      align: "right"
+      align: "right",
+      width: "10%"
     },
     {
       field: "runner",
       name: "Bib",
-      align: "right"
+      align: "right",
+      width: "10%"
     },
     {
       field: "in",
       name: "In Time",
-      render: formatDate
+      render: formatDate,
+      width: "15%"
     },
     {
       field: "out",
       name: "Out Time",
-      render: formatDate
+      render: formatDate,
+      width: "15%"
     },
     {
       field: "dnfType",
       name: "DNF",
-      render: renderDNFTag
+      render: renderDNFTag,
+      sortFn: sortDNF,
+      width: "10%"
     },
     {
       field: "note",

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -1,10 +1,27 @@
 import { Stack } from "~/components";
+import { Tag } from "~/components/Tag";
 import { ColumnDef, DataGrid } from "~/features/DataGrid";
 import { formatDate } from "~/lib/datetimes";
 import { DNFType } from "$shared/enums";
 import { EditRunner } from "./EditRunner";
 import { RunnerFormStats } from "./RunnerFormStats";
 import { RunnerEx, useRunnerData } from "../../hooks/data/useRunnerData";
+
+const renderDNFTag = (dnfType?: DNFType) => {
+  switch (dnfType) {
+    case DNFType.Withdrew:
+      return <Tag color="turquoise">Withdrew</Tag>;
+    case DNFType.Timeout:
+      return <Tag color="purple">Time</Tag>;
+    case DNFType.Medical:
+      return <Tag color="red">Medical</Tag>;
+    case DNFType.Unknown:
+      return <Tag color="red">Unknown</Tag>;
+    case DNFType.None:
+    default:
+      return <> </>;
+  }
+};
 
 export function RunnerEntry() {
   const { data: runnerData } = useRunnerData();
@@ -23,17 +40,17 @@ export function RunnerEntry() {
     {
       field: "in",
       name: "In Time",
-      render: (value) => formatDate(value)
+      render: formatDate
     },
     {
       field: "out",
       name: "Out Time",
-      render: (value) => formatDate(value)
+      render: formatDate
     },
     {
       field: "dnfType",
       name: "DNF",
-      render: (value) => value == (DNFType.None || undefined ? "" : value)
+      render: renderDNFTag
     },
     {
       field: "note",

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -1,20 +1,23 @@
 import { Stack } from "~/components";
 import { ColumnDef, DataGrid } from "~/features/DataGrid";
 import { formatDate } from "~/lib/datetimes";
+import { DNFType } from "$shared/enums";
 import { EditRunner } from "./EditRunner";
 import { RunnerFormStats } from "./RunnerFormStats";
-import { RunnerWithSequence, useRunnerData } from "../../hooks/data/useRunnerData";
+import { RunnerEx, useRunnerData } from "../../hooks/data/useRunnerData";
 
 export function RunnerEntry() {
   const { data: runnerData } = useRunnerData();
 
-  const columns: ColumnDef<RunnerWithSequence> = [
+  const columns: ColumnDef<RunnerEx> = [
     {
       field: "sequence",
+      name: "Seq",
       align: "right"
     },
     {
       field: "runner",
+      name: "Bib",
       align: "right"
     },
     {
@@ -28,8 +31,15 @@ export function RunnerEntry() {
       render: (value) => formatDate(value)
     },
     {
+      field: "dnfType",
+      name: "DNF",
+      render: (value) => value == (DNFType.None || undefined ? "" : value)
+    },
+    {
       field: "note",
-      sortable: false
+      name: "Notes",
+      sortable: false,
+      width: "30%"
     }
   ];
 

--- a/src/renderer/src/features/RunnerEntry/Stats.tsx
+++ b/src/renderer/src/features/RunnerEntry/Stats.tsx
@@ -83,5 +83,11 @@ export function Stats() {
     }
   ];
 
-  return <DataGrid data={stats} columns={Columns} headerClassName="text-primary" />;
+  return (
+    <DataGrid
+      data={stats}
+      columns={Columns}
+      classNames={{ header: "text-primary", table: "table-auto" }}
+    />
+  );
 }

--- a/src/renderer/src/features/RunnerEntry/hooks/useSelectRunnerForm.tsx
+++ b/src/renderer/src/features/RunnerEntry/hooks/useSelectRunnerForm.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useToasts } from "~/features/Toasts/useToasts";
-import { RunnerWithSequence } from "~/hooks/data/useRunnerData";
+import { RunnerEx } from "~/hooks/data/useRunnerData";
 
-export function useSelectRunnerForm(runner: RunnerWithSequence, runners: RunnerWithSequence[]) {
+export function useSelectRunnerForm(runner: RunnerEx, runners: RunnerEx[]) {
   const { createToast } = useToasts();
   const [currentRunner, setCurrentRunner] = useState(runner);
 
-  const form = useForm<RunnerWithSequence>({
+  const form = useForm<RunnerEx>({
     defaultValues: runner,
     values: currentRunner
   });

--- a/src/renderer/src/hooks/data/useRunnerData.tsx
+++ b/src/renderer/src/hooks/data/useRunnerData.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { DNFType } from "$shared/enums";
-import { RunnerDB } from "$shared/models";
+import { RunnerAthleteDB } from "$shared/models";
 import { DatabaseResponse } from "$shared/types";
 import { useHandleStatusToasts } from "../useHandleStatusToasts";
 import { useIpcRenderer } from "../useIpcRenderer";
@@ -15,7 +15,8 @@ export interface Runner {
 
 export interface RunnerEx extends Runner {
   sequence: number;
-  dnfType: DNFType;
+  dnf: boolean;
+  dnfType?: DNFType;
 }
 
 export function useRunnerData() {
@@ -25,21 +26,22 @@ export function useRunnerData() {
   return useQuery({
     queryKey: ["runners-table"],
     queryFn: async (): Promise<RunnerEx[]> => {
-      const response = await ipcRenderer.invoke("get-runners-table");
-      const [data, status, message]: DatabaseResponse<RunnerDB[]> = response;
+      const response = await ipcRenderer.invoke("get-runners-table", { includeDNF: true });
+      const [data, status, message]: DatabaseResponse<RunnerAthleteDB[]> = response;
 
       const success = handleError(status, message);
 
       if (!success) return [];
 
-      return data!.map((runner: RunnerDB, index: number) => ({
+      return data!.map((runner, index) => ({
         id: runner.index,
         sequence: index + 1,
         runner: runner.bibId,
         in: runner.timeIn,
         out: runner.timeOut,
         note: runner.note,
-        dnfType: DNFType.Unknown // TODO: get athlete dnf info
+        dnf: runner.dnf ?? false,
+        dnfType: runner.dnfType
       }));
     }
   });

--- a/src/renderer/src/hooks/data/useRunnerData.tsx
+++ b/src/renderer/src/hooks/data/useRunnerData.tsx
@@ -16,7 +16,7 @@ export interface Runner {
 export interface RunnerEx extends Runner {
   sequence: number;
   dnf: boolean;
-  dnfType?: DNFType;
+  dnfType: DNFType;
 }
 
 export function useRunnerData() {
@@ -41,7 +41,7 @@ export function useRunnerData() {
         out: runner.timeOut,
         note: runner.note,
         dnf: runner.dnf ?? false,
-        dnfType: runner.dnfType
+        dnfType: runner.dnfType ?? DNFType.None
       }));
     }
   });

--- a/src/renderer/src/hooks/data/useRunnerData.tsx
+++ b/src/renderer/src/hooks/data/useRunnerData.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { DNFType } from "$shared/enums";
 import { RunnerDB } from "$shared/models";
 import { DatabaseResponse } from "$shared/types";
 import { useHandleStatusToasts } from "../useHandleStatusToasts";
@@ -12,8 +13,9 @@ export interface Runner {
   note: string;
 }
 
-export interface RunnerWithSequence extends Runner {
+export interface RunnerEx extends Runner {
   sequence: number;
+  dnfType: DNFType;
 }
 
 export function useRunnerData() {
@@ -22,7 +24,7 @@ export function useRunnerData() {
 
   return useQuery({
     queryKey: ["runners-table"],
-    queryFn: async (): Promise<RunnerWithSequence[]> => {
+    queryFn: async (): Promise<RunnerEx[]> => {
       const response = await ipcRenderer.invoke("get-runners-table");
       const [data, status, message]: DatabaseResponse<RunnerDB[]> = response;
 
@@ -36,7 +38,8 @@ export function useRunnerData() {
         runner: runner.bibId,
         in: runner.timeIn,
         out: runner.timeOut,
-        note: runner.note
+        note: runner.note,
+        dnfType: DNFType.Unknown // TODO: get athlete dnf info
       }));
     }
   });

--- a/src/renderer/src/hooks/dom/useTruncated.tsx
+++ b/src/renderer/src/hooks/dom/useTruncated.tsx
@@ -1,0 +1,19 @@
+import { ReactNode, useLayoutEffect, useRef, useState } from "react";
+
+export function useTruncated<T extends HTMLElement>(content: ReactNode) {
+  const ref = useRef<T | null>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const findTruncated = () => setIsTruncated(Boolean(el) && el.scrollWidth > el.clientWidth);
+
+    findTruncated();
+    window.addEventListener("resize", () => findTruncated());
+    return () => window.removeEventListener("resize", findTruncated);
+  }, [content]);
+
+  return [ref, isTruncated] as const;
+}

--- a/src/renderer/src/lib/primeReactTheme/tooltip.ts
+++ b/src/renderer/src/lib/primeReactTheme/tooltip.ts
@@ -28,6 +28,6 @@ export const TooltipPT: TooltipPassThroughOptions = {
   }),
   text: {
     className:
-      "p-3 whitespace-pre-line break-words rounded-md text-on-component bg-surface-tertiary font-display fonty-medium"
+      "p-3 whitespace-pre-line break-words rounded-md text-on-component bg-surface-tertiary font-display font-medium"
   }
 };

--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -1,4 +1,4 @@
-import { EntryMode, RecordType } from "./enums";
+import { DNFType, EntryMode, RecordType } from "./enums";
 
 /**
  * Custom models (types) for ultra-tracker
@@ -46,7 +46,7 @@ export type AthleteDB = {
   emergencyName: string;
   dns: boolean | undefined;
   dnf: boolean | undefined;
-  dnfType: string | undefined;
+  dnfType: DNFType | undefined;
   dnfStation: string | undefined;
   dnfDateTime: Date | null;
   note: string | undefined;
@@ -132,3 +132,5 @@ export type EventLogRec = {
   sent: boolean | undefined;
   verbose: boolean | undefined;
 };
+
+export type RunnerAthleteDB = RunnerDB & Pick<AthleteDB, "dnf" | "dnfType">;


### PR DESCRIPTION
### Changelog

#### Features
- Added Tag component
- readRunnersTable can now query on a join to get DNF + StaEvents table
- Runner Entry table now has a DNF column and shows DNF status in a tag
- Runner DNF populates select field in Edit Runner
- Truncate and add a tooltip to long Datagrid cell values 

#### Fixes
- Fixed keyFn for Log Datagrid
- Fix null StaEvent notes being incorrectly rendered in the Runner Entry datagrid

#### Notes
- It is not yet possible to edit an Athlete's DNFType from the frontend, this is unfinished.