### PR TITLE
App  Logging now in file as well as console 

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "class-variance-authority": "^0.7.0",
     "csv-parse": "^5.5.6",
     "date-fns": "^3.6.0",
+    "electron-log": "^5.2.0",
     "electron-settings": "^4.0.4",
     "electron-updater": "^6.2.1",
     "focus-trap-react": "^10.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      electron-log:
+        specifier: ^5.2.0
+        version: 5.2.0
       electron-settings:
         specifier: ^4.0.4
         version: 4.0.4(electron@28.3.3)
@@ -1770,6 +1773,10 @@ packages:
 
   electron-devtools-installer@3.2.0:
     resolution: {integrity: sha512-t3UczsYugm4OAbqvdImMCImIMVdFzJAHgbwHpkl5jmfu1izVgUcP/mnrPqJIpEeCK1uZGpt+yHgWEN+9EwoYhQ==}
+
+  electron-log@5.2.0:
+    resolution: {integrity: sha512-VjLkvaLmbP3AOGOh5Fob9M8bFU0mmeSAb5G2EoTBx+kQLf2XA/0byzjsVGBTHhikbT+m1AB27NEQUv9wX9nM8w==}
+    engines: {node: '>= 14'}
 
   electron-publish@24.13.1:
     resolution: {integrity: sha512-2ZgdEqJ8e9D17Hwp5LEq5mLQPjqU3lv/IALvgp+4W8VeNhryfGhYEQC/PgDPMrnWUp+l60Ou5SJLsu+k4mhQ8A==}
@@ -6017,6 +6024,8 @@ snapshots:
       semver: 7.6.3
       tslib: 2.6.3
       unzip-crx-3: 0.2.0
+
+  electron-log@5.2.0: {}
 
   electron-publish@24.13.1:
     dependencies:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import { initializeIpcHandlers } from "./ipc/init-ipc";
 import { installDevTools, openDevToolsOnDomReady } from "./lib/devtools";
 import { initUserDirectories } from "./lib/file-dialogs";
 import { initStatEngine } from "./lib/stat-engine";
+import * as logger from "./lib/logger";
 import * as appSettings from "../preload/data";
 
 function createWindow(): BrowserWindow {
@@ -49,6 +50,7 @@ app.on("ready", async () => {
 
   await installDevTools();
 
+  logger.initialize();
   appSettings.firstRun();
   initUserDirectories();
   createDatabaseConnection();
@@ -67,6 +69,7 @@ app.on("ready", async () => {
       if (process.platform !== "darwin") {
         app.quit();
       }
+      logger.shutdown();
     });
   });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,8 +7,8 @@ import { validateDatabaseTables } from "./database/tables-db";
 import { initializeIpcHandlers } from "./ipc/init-ipc";
 import { installDevTools, openDevToolsOnDomReady } from "./lib/devtools";
 import { initUserDirectories } from "./lib/file-dialogs";
+import { LogLevel, initialize, shutdown, uberLog } from "./lib/logger";
 import { initStatEngine } from "./lib/stat-engine";
-import * as logger from "./lib/logger";
 import * as appSettings from "../preload/data";
 
 function createWindow(): BrowserWindow {
@@ -42,7 +42,7 @@ function createWindow(): BrowserWindow {
 }
 
 app.on("ready", async () => {
-  console.log("Application execution path:" + app.getAppPath());
+  uberLog(LogLevel.info, "startup", "Application execution path:" + app.getAppPath(), false);
 
   electronApp.setAppUserModelId("com.electron");
 
@@ -50,7 +50,7 @@ app.on("ready", async () => {
 
   await installDevTools();
 
-  logger.initialize();
+  initialize();
   appSettings.firstRun();
   initUserDirectories();
   createDatabaseConnection();
@@ -69,7 +69,7 @@ app.on("ready", async () => {
       if (process.platform !== "darwin") {
         app.quit();
       }
-      logger.shutdown();
+      shutdown();
     });
   });
 

--- a/src/main/lib/logger.ts
+++ b/src/main/lib/logger.ts
@@ -19,6 +19,38 @@ export function initialize() {
     path.join(app.getPath("documents"), app.name, ".logs/main.log");
   log.errorHandler.startCatching();
   log.transports.console.format = "[{iso}] [{level}] [{processType}] {text}";
+  // Override console methods to log both to console and electron-log
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  const originalInfo = console.info;
+  const originalDebug = console.debug;
+
+  console.log = (...args: unknown[]) => {
+    log.log(...args); // Log to electron-log
+    originalLog(...args); // Log to console
+  };
+
+  console.error = (...args: unknown[]) => {
+    log.error(...args); // Log to electron-log
+    originalError(...args); // Log to console
+  };
+
+  console.warn = (...args: unknown[]) => {
+    log.warn(...args); // Log to electron-log
+    originalWarn(...args); // Log to console
+  };
+
+  console.info = (...args: unknown[]) => {
+    log.info(...args); // Log to electron-log
+    originalInfo(...args); // Log to console
+  };
+
+  console.debug = (...args: unknown[]) => {
+    log.debug(...args); // Log to electron-log
+    originalDebug(...args); // Log to console
+  };
+
   uberLog(LogLevel.info, "startup", "Initializing application: Log from the main process", false);
 }
 

--- a/src/main/lib/logger.ts
+++ b/src/main/lib/logger.ts
@@ -1,0 +1,19 @@
+import path from "path";
+import { app } from "electron";
+import log from "electron-log/main";
+
+// By default, two transports are active: console and file.
+export function initialize() {
+  log.initialize();
+  log.transports.file.resolvePathFn = () =>
+    path.join(app.getPath("documents"), app.name, ".logs/main.log");
+  log.errorHandler.startCatching();
+  //log.transports.console.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}';
+  log.info("Log from the main process");
+}
+
+export function shutdown() {
+  log.errorHandler.stopCatching();
+}
+
+//export function logEvent() {}

--- a/src/main/lib/logger.ts
+++ b/src/main/lib/logger.ts
@@ -1,6 +1,16 @@
 import path from "path";
 import { app } from "electron";
 import log from "electron-log/main";
+import { logEvent } from "../database/eventLogger-db";
+
+export enum LogLevel {
+  error,
+  warn,
+  info,
+  verbose,
+  debug,
+  silly
+}
 
 // By default, two transports are active: console and file.
 export function initialize() {
@@ -8,12 +18,44 @@ export function initialize() {
   log.transports.file.resolvePathFn = () =>
     path.join(app.getPath("documents"), app.name, ".logs/main.log");
   log.errorHandler.startCatching();
-  //log.transports.console.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}';
-  log.info("Log from the main process");
+  log.transports.console.format = "[{iso}] [{level}] [{processType}] {text}";
+  uberLog(LogLevel.info, "startup", "Initializing application: Log from the main process", false);
 }
 
 export function shutdown() {
   log.errorHandler.stopCatching();
 }
 
-//export function logEvent() {}
+export function uberLog(level: LogLevel, scope: string, message: string, sendToEventLog: boolean) {
+  const scopedLog = !scope ? log : log.scope(scope);
+  const logMessage = `${message}`;
+
+  if (sendToEventLog)
+    logEvent(-1, null, null, null, new Date().toISOString(), logMessage, false, false);
+
+  switch (level) {
+    case LogLevel.error:
+      scopedLog.error(logMessage);
+      break;
+
+    case LogLevel.warn:
+      scopedLog.warn(logMessage);
+      break;
+
+    case LogLevel.info:
+      scopedLog.info(logMessage);
+      break;
+
+    case LogLevel.verbose:
+      scopedLog.verbose(logMessage);
+      break;
+
+    case LogLevel.debug:
+      scopedLog.debug(logMessage);
+      break;
+
+    case LogLevel.silly:
+      scopedLog.silly(logMessage);
+      break;
+  }
+}

--- a/src/preload/data.ts
+++ b/src/preload/data.ts
@@ -54,11 +54,6 @@ export const configureAppSettings = () => {
 
 export const resetAppSettings = () => {
   appSettings.reset();
-  initializeDefaultAppSettings();
-};
-
-export const getAppSettings = () => {
-  appSettings.reset();
   configureAppSettings();
   initializeDefaultAppSettings();
 };

--- a/src/renderer/src/features/SettingsHub/SettingsHub.tsx
+++ b/src/renderer/src/features/SettingsHub/SettingsHub.tsx
@@ -1,6 +1,8 @@
+import log from "electron-log/renderer";
 import { Button, Stack } from "~/components";
 import * as dbUtilHooks from "~/hooks/ipc/useDatabaseUtilities";
 import * as dialogHooks from "~/hooks/ipc/useFileDialogs";
+import * as loggerHooks from "~/hooks/ipc/useLogger";
 import * as settingsHooks from "~/hooks/ipc/useSettingsUtilities";
 import { useToasts } from "../Toasts/useToasts";
 
@@ -17,6 +19,8 @@ export function SettingsHub() {
   const { createToast } = useToasts();
 
   const resetAppSettings = () => {
+    log.info("testing renderer to main log");
+    loggerHooks.useMainLogger("warning", "User click: Reset App Settings");
     createToast({ message: "App Settings: Resetting", type: "info" });
     resetAppSettingsMutation.mutate("resetAppSettings");
   };

--- a/src/renderer/src/hooks/ipc/useLogger.tsx
+++ b/src/renderer/src/hooks/ipc/useLogger.tsx
@@ -1,0 +1,13 @@
+import { useIpcRenderer } from "../useIpcRenderer";
+
+export function useMainLogger(level: string, message: string) {
+  const ipcRenderer = useIpcRenderer();
+
+  ipcRenderer.send("__ELECTRON_LOG__", {
+    // LogMessage-like object
+    data: [message],
+    level: level,
+    variables: { processType: "renderer" }
+    // ... some other optional fields like scope, logId and so on
+  });
+}


### PR DESCRIPTION
### **Change Log** 

**Features**

-  init and config main logger, will also be used for renderer logging if needed
- use logger via renderer in two ways, as examples for now
- Added Uber logging function that tries to handle all log types uniformly
- pointed the console log messages to use the electron log messages (console messages are now logged into the console as well as the app log file)


**Chores**
- cleanup unused duplicate functions, will reimplement when needed