### PR TITLE
fix(workflow): github actions need permissions to update releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ on:
   push:
     tags:
       - v*.*.*
+
+# Releases need permissions to read and write the repository contents.
+# GitHub considers creating releases and uploading assets as writing contents.
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
# Changelog
## Fixes
* Added permissions to the build definition for releases

Notes: Releases need permissions to read and write the repository contents.
GitHub considers creating releases and uploading assets as writing contents.