### PR TITLE
Note Changes & RFID Startline Check

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.5.12",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.20",
     "electron": "^28.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      '@types/ws':
+        specifier: ^8.5.12
+        version: 8.5.12
       '@vitejs/plugin-react':
         specifier: ^4.3.1
         version: 4.3.1(vite@5.4.0(@types/node@18.19.44))
@@ -1023,6 +1026,9 @@ packages:
 
   '@types/verror@1.10.10':
     resolution: {integrity: sha512-l4MM0Jppn18hb9xmM6wwD1uTdShpf9Pn80aXTStnK1C94gtPvJcV2FrDmbOQUAQfJ1cKZHktkQUDwEqaAKXMMg==}
+
+  '@types/ws@8.5.12':
+    resolution: {integrity: sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -5150,6 +5156,10 @@ snapshots:
 
   '@types/verror@1.10.10':
     optional: true
+
+  '@types/ws@8.5.12':
+    dependencies:
+      '@types/node': 18.19.44
 
   '@types/yauzl@2.10.3':
     dependencies:

--- a/src/main/api/rfid-processor.ts
+++ b/src/main/api/rfid-processor.ts
@@ -7,13 +7,13 @@
 / USER APPS repo for Zebra https://github.com/ZebraDevs/RFID_ZIOTC_Examples
 // Documentation: https://zebradevs.github.io/rfid-ziotc-docs/setupziotc/index.html#start-reads
 */
+
 import { EventEmitter } from "events";
 import WebSocket from "ws";
 import { DeviceStatus } from "../../shared/enums";
 import * as dbTimings from "../database/timingRecords-db";
 import * as rfidEmitter from "../ipc/rfid-emitter";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 let rfidWebSocketProcessor: RFIDWebSocketProcessor | null = null;
 const rfidReaderUrl = "wss://169.254.78.28/ws:80"; //trying to connect via host name.
 

--- a/src/main/database/stations-db.ts
+++ b/src/main/database/stations-db.ts
@@ -47,9 +47,9 @@ export async function LoadStations() {
 
   for (const index in stationData) {
     if (index == "event") {
-      await appStore.set("event.name", stationData.event.name);
-      await appStore.set("event.starttime", formatDate(stationData.event.starttime));
-      await appStore.set("event.endtime", formatDate(stationData.event.endtime));
+      appStore.set("event.name", stationData.event.name);
+      appStore.set("event.starttime", formatDate(stationData.event.starttime));
+      appStore.set("event.endtime", formatDate(stationData.event.endtime));
     }
 
     if (index == "stations") {
@@ -62,9 +62,9 @@ export async function LoadStations() {
       }
 
       for (const key in stationData.stations) {
-        if (key == "0") await appStore.set("event.startline", stationData[index][key].identifier);
+        if (key == "0") appStore.set("event.startline", stationData[index][key].identifier);
         if (key == (stationData.stations.length - 1).toString())
-          await appStore.set("event.finishline", stationData[index][key].identifier);
+          appStore.set("event.finishline", stationData[index][key].identifier);
 
         insertStation(stationData[index][key]);
       }
@@ -80,28 +80,22 @@ export async function setStation(stationIdentifier: string) {
   const selectedStation: Station | null = GetStationByIdentifier(stationIdentifier)?.[0];
   if (!selectedStation) return;
 
-  await appStore.set("station.name", selectedStation.name);
-  await appStore.set("station.id", Number(selectedStation.identifier.split("-", 1)[0]));
-  await appStore.set("station.identifier", selectedStation.identifier);
-  await appStore.set("station.entrymode", selectedStation.entrymode);
-  await appStore.set(`station.shiftBegin`, formatDate(selectedStation.shiftBegin));
-  await appStore.set(`station.cutofftime`, formatDate(selectedStation.cutofftime));
-  await appStore.set(`station.shiftEnd`, formatDate(selectedStation.shiftEnd));
+  appStore.set("station.name", selectedStation.name);
+  appStore.set("station.id", Number(selectedStation.identifier.split("-", 1)[0]));
+  appStore.set("station.identifier", selectedStation.identifier);
+  appStore.set("station.entrymode", selectedStation.entrymode);
+  appStore.set(`station.shiftBegin`, formatDate(selectedStation.shiftBegin));
+  appStore.set(`station.cutofftime`, formatDate(selectedStation.cutofftime));
+  appStore.set(`station.shiftEnd`, formatDate(selectedStation.shiftEnd));
 
   for (const key in selectedStation.operators) {
-    await appStore.set(
-      `station.operators.${key}.fullname`,
-      selectedStation.operators[key].fullname
-    );
-    await appStore.set(
-      `station.operators.${key}.callsign`,
-      selectedStation.operators[key].callsign
-    );
-    await appStore.set(`station.operators.${key}.phone`, selectedStation.operators[key].phone);
-    await appStore.set(`station.operators.${key}.active`, false);
+    appStore.set(`station.operators.${key}.fullname`, selectedStation.operators[key].fullname);
+    appStore.set(`station.operators.${key}.callsign`, selectedStation.operators[key].callsign);
+    appStore.set(`station.operators.${key}.phone`, selectedStation.operators[key].phone);
+    appStore.set(`station.operators.${key}.active`, false);
   }
 
-  await appStore.set("station.operators.primary.active", true);
+  appStore.set("station.operators.primary.active", true);
 }
 
 export async function SetStationIdentity(params: SetStationIdentityParams) {
@@ -113,7 +107,7 @@ export async function SetStationIdentity(params: SetStationIdentityParams) {
   );
 
   for (const operator in settings.operators) {
-    await appStore.set(`station.operators.${operator}.active`, false);
+    appStore.set(`station.operators.${operator}.active`, false);
   }
 
   appStore.set(`station.operators.${key}.active`, true);

--- a/src/main/ipc/init-ipc.ts
+++ b/src/main/ipc/init-ipc.ts
@@ -8,6 +8,7 @@ import { initRunnerFormHandlers } from "./runnerform-ipc";
 import { initSettingsHandlers } from "./settings-ipc";
 import { initStationHandlers } from "./stations-ipc";
 import { initStatsHandlers } from "./stats-ipc";
+import { initStoreHandlers } from "./store-ipc";
 
 export function initializeIpcHandlers() {
   initAthleteHandlers();
@@ -20,4 +21,5 @@ export function initializeIpcHandlers() {
   initSettingsHandlers();
   initStatsHandlers();
   initStationHandlers();
+  initStoreHandlers();
 }

--- a/src/main/ipc/rfid-emitter.ts
+++ b/src/main/ipc/rfid-emitter.ts
@@ -1,4 +1,4 @@
-import { RFIDReaderStatus } from "../../shared/enums";
+import { DeviceStatus } from "../../shared/enums";
 import { GetWebContents } from "../lib/webContents";
 
 export const hasReadRFID = () => {
@@ -6,7 +6,7 @@ export const hasReadRFID = () => {
   webContents?.send("read-rfid");
 };
 
-export const statusRFID = (status: RFIDReaderStatus, message: string) => {
+export const statusRFID = (status: DeviceStatus, message: string) => {
   const webContents = GetWebContents();
   webContents?.send("status-rfid", status, message);
 };

--- a/src/main/ipc/store-ipc.ts
+++ b/src/main/ipc/store-ipc.ts
@@ -1,0 +1,24 @@
+import { ipcMain } from "electron";
+import { appStore } from "../lib/store";
+import { Handler } from "../types";
+
+type TypedKey = Parameters<typeof appStore.delete>[0];
+
+const getStoreValue: Handler<string, unknown> = (_, storeKey) => appStore.get(storeKey);
+const hasStoreValue: Handler<string, boolean> = (_, storeKey) => appStore.has(storeKey);
+const deleteStoreValue: Handler<TypedKey> = (_, storeKey) => appStore.delete(storeKey);
+const resetStoreValue: Handler<TypedKey> = (_, storeKey) => appStore.reset(storeKey);
+const clearStore: Handler<void, void> = () => appStore.clear();
+
+const setStoreValue: Handler<{ key: string; value: unknown }> = (_, { key, value }) => {
+  return appStore.set(key, value);
+};
+
+export const initStoreHandlers = () => {
+  ipcMain.handle("get-store-value", getStoreValue);
+  ipcMain.handle("set-store-value", setStoreValue);
+  ipcMain.handle("has-store-value", hasStoreValue);
+  ipcMain.handle("reset-store-value", resetStoreValue);
+  ipcMain.handle("delete-store-value", deleteStoreValue);
+  ipcMain.handle("clear-store", clearStore);
+};

--- a/src/main/lib/store.ts
+++ b/src/main/lib/store.ts
@@ -1,49 +1,4 @@
-const Store = require("electron-store");
-
-const schema = {
-  initialized: { type: "boolean", default: false },
-  targetLanguage: { type: "string", default: "eng" },
-  incrementalFileIndex: { type: "number", default: 1 },
-  event: {
-    type: "object",
-    properties: {
-      name: { type: "string", default: "" },
-      startline: { type: "string", default: "" },
-      starttime: { type: "string", default: "" },
-      finishline: { type: "string", default: "" },
-      endtime: { type: "string", default: "" }
-    }
-    //required: ["name", "startline", "finishline"]
-  },
-  station: {
-    type: "object",
-    properties: {
-      id: { type: "number", default: 0 },
-      identifier: { type: "string", default: "" },
-      name: { type: "string", default: "" },
-      entryMode: { enum: ["Normal", "Fast", "InOnly", "OutOnly"], default: "Normal" },
-      shiftBegin: { type: "string", default: "00:00:00 Jan 01 2024" },
-      shiftEnd: { type: "string", default: "00:00:00 Jan 01 2024" },
-      entrymode: { type: "number", default: 0 },
-      operators: {
-        type: "object",
-        properties: {
-          primary: {
-            type: "object",
-            properties: {
-              fullname: { type: "string", default: "" },
-              callsign: { type: "string", default: "" },
-              phone: { type: "string", default: "" }
-            }
-          }
-          //required: ["fullname, callsign"]
-        }
-      }
-    }
-    //required: ["primary"]
-  }
-  //required: ["id", "identifier", "name", "entryMode", "operators"]
-};
+import Store from "electron-store";
 
 const defaults = {
   initialized: false,
@@ -68,19 +23,65 @@ const defaults = {
       primary: {
         fullname: "Percy L. Spencer",
         callsign: "W1GBE-SK",
-        phone: "999-999-9999"
+        phone: "999-999-9999",
+        active: false
       },
       secondary: {
         fullname: "Nolan Bushnell",
         callsign: "W7DUK-SK",
-        phone: "999-999-9999"
+        phone: "999-999-9999",
+        active: false
       }
     }
   }
 };
 
 export const appStore = new Store({
-  schema: schema,
+  schema: {
+    initialized: { type: "boolean", default: false },
+    targetLanguage: { type: "string", default: "eng" },
+    incrementalFileIndex: { type: "number", default: 1 },
+    event: {
+      type: "object",
+      properties: {
+        name: { type: "string", default: "" },
+        startline: { type: "string", default: "" },
+        starttime: { type: "string", default: "" },
+        finishline: { type: "string", default: "" },
+        endtime: { type: "string", default: "" }
+      }
+      //required: ["name", "startline, "finishline"]
+    },
+    station: {
+      type: "object",
+      properties: {
+        id: { type: "number", default: 0 },
+        identifier: { type: "string", default: "" },
+        name: { type: "string", default: "" },
+        entryMode: { enum: ["Normal", "Fast", "InOnly", "OutOnly"], default: "Normal" },
+        shiftBegin: { type: "string", default: "00:00:00 Jan 01 2024" },
+        shiftEnd: { type: "string", default: "00:00:00 Jan 01 2024" },
+        entrymode: { type: "number", default: 0 },
+        operators: {
+          type: "object",
+          properties: {
+            primary: {
+              type: "object",
+              properties: {
+                fullname: { type: "string", default: "" },
+                callsign: { type: "string", default: "" },
+                phone: { type: "string", default: "" },
+                active: { type: "boolean", default: false }
+              }
+            }
+            //required: ["fullname, callsign"]
+          }
+        }
+      }
+      //required: ["primary"]
+    }
+    //required: ["id", "identifier", "name", "entryMode", "operators"]
+  },
   defaults: defaults,
   migrations: {},
   clearInvalidConfig: true

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -29,3 +29,7 @@ body {
     margin: 0;
   }
 }
+
+textarea::-webkit-scrollbar {
+   display: none;
+ }

--- a/src/renderer/src/components/TextInput.tsx
+++ b/src/renderer/src/components/TextInput.tsx
@@ -17,10 +17,16 @@ const Input = classed.input({
     isDisabled: {
       true: "text-on-surface",
       false: "text-on-component"
+    },
+    resize: {
+      none: "resize-none",
+      vertical: "resize-y",
+      horizontal: "resize-x"
     }
   },
   defaultVariants: {
-    hasError: false
+    hasError: false,
+    resize: "none"
   }
 });
 
@@ -38,16 +44,28 @@ export interface TextInputProps extends InputProps {
   error?: FieldError;
 }
 
-export const TextInput = forwardRef<HTMLInputElement, TextInputProps>((props, ref) => {
-  const { label, error, labelProps, ...rest } = props;
+export interface TextAreaProps extends TextInputProps {
+  rows?: number;
+  resize?: "none" | "vertical" | "horizontal";
+  maxlength?: number;
+}
+
+type Props = TextInputProps | TextAreaProps;
+
+export const TextInput = forwardRef<HTMLInputElement, Props>((props, ref) => {
+  const { label, error, labelProps, wrapperClassName, ...rest } = props;
+
+  const isTextArea = "rows" in props || "resize" in props;
+
   return (
-    <Stack direction="col" className={`gap-1 ${props.wrapperClassName}`}>
+    <Stack direction="col" className={`gap-1 ${wrapperClassName}`}>
       <Stack direction="row" align="center" className="gap-2.5">
         {label && <Label {...labelProps}>{label}</Label>}
         {error && <WarningIcon width={20} className="fill-warning animate-in slide-in-from-left" />}
       </Stack>
       <Input
         {...rest}
+        as={(isTextArea ? "textarea" : "input") as "input"} // weird ts error
         ref={ref}
         hasError={Boolean(props.error)}
         isDisabled={Boolean(props.disabled)}

--- a/src/renderer/src/features/Footer/Footer.tsx
+++ b/src/renderer/src/features/Footer/Footer.tsx
@@ -7,8 +7,6 @@ import { useStation } from "../../hooks/data/useStation";
 function useFooterInfo() {
   const { data: station } = useStation();
 
-  console.log(station?.operators);
-
   const title = `${station?.identifier.split("-", 1)[0]} ${station?.name}`;
   const operator = Object.values(station?.operators ?? {}).find((operator) => operator.active);
   const callsign = operator ? operator.callsign : "No Active Operator";

--- a/src/renderer/src/features/RunnerEntry/EditRunner.tsx
+++ b/src/renderer/src/features/RunnerEntry/EditRunner.tsx
@@ -205,6 +205,7 @@ export function EditRunner(props: Props) {
                 />
               </Stack>
               <TextInput
+                rows={2}
                 wrapperClassName="w-full"
                 label="Note"
                 placeholder="Note"

--- a/src/renderer/src/features/SettingsPage/SettingsPage.tsx
+++ b/src/renderer/src/features/SettingsPage/SettingsPage.tsx
@@ -1,12 +1,23 @@
 import { useState } from "react";
 import { Button, ConfirmationModal, Stack, VerticalButtonGroup } from "~/components";
+import { useStoreValue } from "~/hooks/ipc/useStoreValue";
 import { useSettingsMutations } from "./hooks/useSettingsMutations";
+
+function useIsStartLine() {
+  const { data: startline } = useStoreValue("event.startline");
+  const { data: stationIdentifier } = useStoreValue("station.identifier");
+
+  if (!startline || !stationIdentifier) return false;
+  return startline === stationIdentifier;
+}
 
 export function SettingsPage() {
   const settingsMutations = useSettingsMutations();
   const [resetOpen, setResetOpen] = useState(false);
   const [recreateOpen, setRecreateOpen] = useState(false);
   const [recoverOpen, setRecoverOpen] = useState(false);
+
+  const isStartLine = useIsStartLine();
 
   return (
     <Stack className="w-full h-full bg-component" justify="center" align="center">
@@ -36,7 +47,11 @@ export function SettingsPage() {
               </Stack>
             }
           >
-            <Button size="wide" onClick={() => settingsMutations.initializeRfid.mutate()}>
+            <Button
+              size="wide"
+              onClick={() => settingsMutations.initializeRfid.mutate()}
+              disabled={!isStartLine}
+            >
               Initialize RFID
             </Button>
           </VerticalButtonGroup>

--- a/src/renderer/src/hooks/ipc/useStoreValue.tsx
+++ b/src/renderer/src/hooks/ipc/useStoreValue.tsx
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { useToasts } from "~/features/Toasts/useToasts";
+import { useIpcRenderer } from "~/hooks/useIpcRenderer";
+
+export function useStoreValue(key: string) {
+  const { createToast } = useToasts();
+  const ipcRenderer = useIpcRenderer();
+
+  return useQuery({
+    queryKey: ["store", "get", "station", key],
+    queryFn: async () => {
+      const response = await ipcRenderer.invoke("get-store-value", key);
+
+      if (response === undefined)
+        createToast({ type: "danger", message: `Store value ${key} not found` });
+
+      return response;
+    }
+  });
+}

--- a/src/shared/enums.ts
+++ b/src/shared/enums.ts
@@ -34,7 +34,7 @@ export enum RecordStatus {
   Duplicate
 }
 
-export enum RFIDReaderStatus {
+export enum DeviceStatus {
   Connected,
   Connecting,
   NoDevice,


### PR DESCRIPTION
### Changelog
#### Features
- Implement multiline mode for Text Input with associated props like row count, max length, resize options
- Update Note field to have two rows
- Edit Runner form now allows commas but replaces them with semicolons, in which case a warning toast appears on save
- Add Store IPC methods (get, set, has, etc) to provide store access to the renderer
- Implement useStoreValue frontend hook
- Only enable the RFID initialize button when station is set to start line
#### Fixes
- Swap most of the valueFns in the Stations columns to render to fix sorting/filtering
#### Chores
- Generalize RFIDReaderStatus to DeviceStatus
- Add @types/ws package for proper type information on  WebSocket package
- Remove awaits that don't do anything in `stations-db.ts`
- Move Store schema into constructor for proper typing
