### PR TITLE
Revert change to prevent empty strings from being set to note fields

### DIFF
--- a/src/main/database/athlete-db.ts
+++ b/src/main/database/athlete-db.ts
@@ -503,7 +503,7 @@ function parseCSVDate(timingDate: string): Date {
 export function syncAthleteNote(bibId: number, note: string, direction: SyncDirection) {
   const db = getDatabaseConnection();
   const athleteResult = GetAthleteByBib(bibId);
-  let combinedNote: string | null = "";
+  let combinedNote: string = "";
 
   if (athleteResult[1] != DatabaseStatus.Success) return;
 
@@ -521,9 +521,6 @@ export function syncAthleteNote(bibId: number, note: string, direction: SyncDire
       combinedNote = athleteNote.concat(" ", combinedNote).trimStart();
       break;
   }
-
-  // don't set empty strings, set null
-  if (combinedNote == "") combinedNote = null;
 
   try {
     db.prepare(`UPDATE StationEvents SET note = ? WHERE "bibId" = ?`).run(combinedNote, bibId);


### PR DESCRIPTION
## Changelog
### Fixes
* revert(notes): revert change to prevent empty strings from being set to note fields
  * this caused downstream failures that didnt check if the field values could be null