### PR TITLE
Both DNS and DNF on Runner Entry Page

### DIFF
--- a/src/renderer/src/components/StatusTag.tsx
+++ b/src/renderer/src/components/StatusTag.tsx
@@ -1,0 +1,42 @@
+import { AthleteStatus, DNFType } from "$shared/enums";
+import { Tag, TagColor } from "./Tag";
+
+interface Props {
+  dnfType?: DNFType;
+  dns?: boolean;
+  athleteStatus?: AthleteStatus;
+}
+
+type TagInfo = { color: TagColor; text: string };
+
+const dnfTypeMap: Record<DNFType, TagInfo | null> = {
+  [DNFType.Withdrew]: { color: "turquoise", text: "Withdrew" },
+  [DNFType.Timeout]: { color: "purple", text: "Timeout" },
+  [DNFType.Medical]: { color: "red", text: "Medical" },
+  [DNFType.Unknown]: { color: "gray", text: "Unknown" },
+  [DNFType.None]: null
+};
+
+const athleteStatusMap: Record<AthleteStatus, TagInfo | null> = {
+  [AthleteStatus.Present]: { color: "orange", text: "➠ In" },
+  [AthleteStatus.Outgoing]: { color: "lightgray", text: "Out ➠" },
+  [AthleteStatus.Incoming]: null
+};
+
+function getStatusColor(props: Props): TagInfo | null {
+  if (props.dnfType) {
+    return dnfTypeMap[props.dnfType];
+  } else if (props.dns) {
+    return { color: "blue", text: "DNS" };
+  } else if (props.athleteStatus) {
+    return athleteStatusMap[props.athleteStatus];
+  } else {
+    return null;
+  }
+}
+
+export function StatusTag(props: Props) {
+  const tagInfo = getStatusColor(props);
+  if (!tagInfo) return null;
+  return <Tag color={tagInfo.color}>{tagInfo.text}</Tag>;
+}

--- a/src/renderer/src/components/StatusTag.tsx
+++ b/src/renderer/src/components/StatusTag.tsx
@@ -5,6 +5,7 @@ interface Props {
   dnfType?: DNFType;
   dns?: boolean;
   athleteStatus?: AthleteStatus;
+  duplicate?: boolean;
 }
 
 type TagInfo = { color: TagColor; text: string };
@@ -24,7 +25,9 @@ const athleteStatusMap: Record<AthleteStatus, TagInfo | null> = {
 };
 
 function getStatusColor(props: Props): TagInfo | null {
-  if (props.dnfType) {
+  if (props.duplicate) {
+    return { color: "red", text: "Duplicate" };
+  } else if (props.dnfType) {
     return dnfTypeMap[props.dnfType];
   } else if (props.dns) {
     return { color: "blue", text: "DNS" };

--- a/src/renderer/src/components/Tag.tsx
+++ b/src/renderer/src/components/Tag.tsx
@@ -3,6 +3,7 @@ import { VariantProps } from "class-variance-authority";
 import { classed } from "~/lib/classed";
 
 type TagVariants = VariantProps<typeof TagWrapper>;
+export type TagColor = TagVariants["color"];
 
 // TODO: Support icons in tag component
 interface TagProps {

--- a/src/renderer/src/components/TextInput.tsx
+++ b/src/renderer/src/components/TextInput.tsx
@@ -59,13 +59,18 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props, ref) => {
 
   return (
     <Stack direction="col" className={`gap-1 ${wrapperClassName}`}>
-      <Stack direction="row" align="center" className="gap-2.5">
-        {label && <Label {...labelProps}>{label}</Label>}
-        {error && <WarningIcon width={20} className="fill-warning animate-in slide-in-from-left" />}
-      </Stack>
+      {(label || error) && (
+        <Stack direction="row" align="center" className="gap-2.5">
+          {label && <Label {...labelProps}>{label}</Label>}
+          {error && (
+            <WarningIcon width={20} className="fill-warning animate-in slide-in-from-left" />
+          )}
+        </Stack>
+      )}
       <Input
         {...rest}
         as={(isTextArea ? "textarea" : "input") as "input"} // weird ts error
+        resize={isTextArea ? props.resize : undefined}
         ref={ref}
         hasError={Boolean(props.error)}
         isDisabled={Boolean(props.disabled)}

--- a/src/renderer/src/features/DataGrid/TableContent.tsx
+++ b/src/renderer/src/features/DataGrid/TableContent.tsx
@@ -43,7 +43,11 @@ export function TableContent<T extends object>(props: Props<T>) {
           ref={props.rowVirtualizer.measureElement}
         >
           {props.columns.map((column) => (
-            <Cell key={column.name ?? String(column.field)} align={column.align ?? "left"}>
+            <Cell
+              key={column.name ?? String(column.field)}
+              align={column.align ?? "left"}
+              truncate={column.truncate !== false}
+            >
               {renderCell(column, props.data[row.index])}
             </Cell>
           ))}

--- a/src/renderer/src/features/DataGrid/TableContent.tsx
+++ b/src/renderer/src/features/DataGrid/TableContent.tsx
@@ -50,8 +50,9 @@ export function TableContent<T extends object>(props: Props<T>) {
           {!props.actionButtons && <CellWrapper />}
           {props.actionButtons && (
             <CellWrapper
+              truncate={false}
               align="right"
-              className="p-0 opacity-0 h-inherit group-hover/row:opacity-100"
+              className="p-0 pr-4 opacity-0 h-inherit group-hover/row:opacity-100"
             >
               {props.actionButtons(props.data[row.index])}
             </CellWrapper>

--- a/src/renderer/src/features/DataGrid/components/Cell.tsx
+++ b/src/renderer/src/features/DataGrid/components/Cell.tsx
@@ -5,12 +5,15 @@ import { useTruncated } from "~/hooks/dom/useTruncated";
 import { classed } from "~/lib/classed";
 
 export const CellWrapper = classed.td(
-  "overflow-hidden py-1 px-4 h-full text-sm font-medium text-end truncate",
+  "overflow-hidden py-1 px-4 h-full text-sm font-medium text-end",
   {
     variants: {
       align: {
         right: "text-right",
         left: "text-left"
+      },
+      truncate: {
+        true: "truncate"
       }
     }
   }
@@ -19,6 +22,7 @@ export const CellWrapper = classed.td(
 interface CellProps {
   children: React.ReactNode;
   align: "left" | "right";
+  truncate?: boolean;
 }
 
 export function Cell(props: CellProps) {
@@ -30,9 +34,14 @@ export function Cell(props: CellProps) {
   const [cellRef, truncated] = useTruncated<HTMLTableCellElement>(props.children);
 
   return (
-    <CellWrapper align={props.align} ref={cellRef} className={cellId}>
+    <CellWrapper
+      align={props.align}
+      ref={cellRef}
+      className={cellId}
+      truncate={props.truncate !== false}
+    >
       {props.children}
-      {truncated && (
+      {props.truncate && truncated && (
         <Tooltip
           position="top"
           target={`.${cellId}`}

--- a/src/renderer/src/features/DataGrid/types.ts
+++ b/src/renderer/src/features/DataGrid/types.ts
@@ -10,6 +10,7 @@ export type Column<T extends object> = {
     sortable?: boolean;
     render?: (value: T[K], row: T) => ReactNode;
     align?: "left" | "right";
+    truncate?: boolean;
   };
 }[keyof T];
 

--- a/src/renderer/src/features/RosterPage/RosterPage.tsx
+++ b/src/renderer/src/features/RosterPage/RosterPage.tsx
@@ -1,55 +1,10 @@
 import { getRouteApi, useNavigate } from "@tanstack/react-router";
-import { Tag } from "~/components/Tag";
+import { StatusTag } from "~/components/StatusTag";
 import { useAthletes } from "~/hooks/data/useAthletes";
 import { AthleteStatus, DNFType } from "$shared/enums";
 import { AthleteDB } from "$shared/models";
 import { EmergencyContact } from "./EmergencyContact";
 import { ColumnDef, DataGrid } from "../DataGrid";
-
-const renderStatusTag = (dnfType: DNFType, dns: boolean, status: AthleteStatus) => {
-  let tag: JSX.Element;
-
-  if (dns == (undefined || null) && dnfType == (undefined || null)) {
-    return <> </>;
-  } else if (dnfType) {
-    switch (dnfType as DNFType) {
-      case DNFType.Withdrew:
-        tag = <Tag color="turquoise">Withdrew</Tag>;
-        break;
-      case DNFType.Timeout:
-        tag = <Tag color="purple">Timeout</Tag>;
-        break;
-      case DNFType.Medical:
-        tag = <Tag color="red">Medical</Tag>;
-        break;
-      case DNFType.Unknown:
-        tag = <Tag color="gray">Unknown</Tag>;
-        break;
-      case DNFType.None:
-      default:
-        tag = <> </>;
-        break;
-    }
-  } else if (dns) {
-    return <Tag color="blue">DNS</Tag>;
-  } else {
-    switch (status as AthleteStatus) {
-      case AthleteStatus.Incoming:
-        //tag = <Tag color="lightgreen"></Tag>;
-        tag = <> </>;
-        break;
-      case AthleteStatus.Present:
-        tag = <Tag color="orange">➠ In</Tag>;
-        break;
-      case AthleteStatus.Outgoing:
-        tag = <Tag color="lightgray">Out ➠</Tag>;
-        //tag = <>Out</>;
-        break;
-    }
-  }
-
-  return tag;
-};
 
 const routeApi = getRouteApi(`/roster`);
 
@@ -69,7 +24,9 @@ export function RosterPage() {
     {
       field: "dnfType",
       name: "Status",
-      render: (dnfType, { dns, status }) => renderStatusTag(dnfType!, dns!, status!),
+      render: (dnfType, { dns, status }) => (
+        <StatusTag dnfType={dnfType} dns={dns} athleteStatus={status} />
+      ),
       valueFn: (athlete) =>
         `${athlete.dnfType! === DNFType.None ? "" : athlete.dnfType + "dnf"}
          ${athlete.status! === AthleteStatus.Incoming ? "Incoming" : ""}

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -6,20 +6,37 @@ import { EditRunner } from "./EditRunner";
 import { RunnerFormStats } from "./RunnerFormStats";
 import { RunnerEx, useRunnerData } from "../../hooks/data/useRunnerData";
 
-const renderDNFTag = (dnfType?: DNFType) => {
-  switch (dnfType) {
-    case DNFType.Withdrew:
-      return <Tag color="turquoise">Withdrew</Tag>;
-    case DNFType.Timeout:
-      return <Tag color="purple">Timeout</Tag>;
-    case DNFType.Medical:
-      return <Tag color="red">Medical</Tag>;
-    case DNFType.Unknown:
-      return <Tag color="gray">Unknown</Tag>;
-    case DNFType.None:
-    default:
-      return <> </>;
+const renderStatusTag = (dnfType: DNFType, dns: boolean) => {
+  let tag: JSX.Element = <> </>;
+
+  if (dns == (undefined || null) && dnfType == (undefined || null)) {
+    return <> </>;
   }
+  if (dnfType) {
+    switch (dnfType as DNFType) {
+      case DNFType.Withdrew:
+        tag = <Tag color="turquoise">Withdrew</Tag>;
+        break;
+      case DNFType.Timeout:
+        tag = <Tag color="purple">Timeout</Tag>;
+        break;
+      case DNFType.Medical:
+        tag = <Tag color="red">Medical</Tag>;
+        break;
+      case DNFType.Unknown:
+        tag = <Tag color="gray">Unknown</Tag>;
+        break;
+      case DNFType.None:
+      default:
+        tag = <> </>;
+        break;
+    }
+  }
+  if (dns) {
+    tag = <Tag color="blue">DNS</Tag>;
+  }
+
+  return tag;
 };
 
 export function RunnerEntry() {
@@ -52,9 +69,11 @@ export function RunnerEntry() {
     },
     {
       field: "dnfType",
-      name: "DNF",
-      render: renderDNFTag,
-      valueFn: ({ dnfType }) => (dnfType === DNFType.None ? "" : dnfType), // Group DNFs together on sort
+      name: "Status",
+      render: (dnfType, { dns }) => renderStatusTag(dnfType!, dns!),
+      valueFn: (data) =>
+        `${data.dnfType! === DNFType.None ? "" : data.dnfType + "dnf"},
+         ${data.dns! ? "DNS" : ""}`,
       width: "118px"
     },
     {

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -38,6 +38,7 @@ export function RunnerEntry() {
     {
       field: "dnfType",
       name: "Status",
+      truncate: false,
       render: (dnfType, { dns, status }) => (
         <StatusTag dnfType={dnfType} dns={dns} duplicate={status === RecordStatus.Duplicate} />
       ),

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -1,43 +1,11 @@
 import { Stack, Tag } from "~/components";
+import { StatusTag } from "~/components/StatusTag";
 import { ColumnDef, DataGrid } from "~/features/DataGrid";
 import { formatDate } from "~/lib/datetimes";
 import { DNFType } from "$shared/enums";
 import { EditRunner } from "./EditRunner";
 import { RunnerFormStats } from "./RunnerFormStats";
 import { RunnerEx, useRunnerData } from "../../hooks/data/useRunnerData";
-
-const renderStatusTag = (dnfType: DNFType, dns: boolean) => {
-  let tag: JSX.Element = <> </>;
-
-  if (dns == (undefined || null) && dnfType == (undefined || null)) {
-    return <> </>;
-  }
-  if (dnfType) {
-    switch (dnfType as DNFType) {
-      case DNFType.Withdrew:
-        tag = <Tag color="turquoise">Withdrew</Tag>;
-        break;
-      case DNFType.Timeout:
-        tag = <Tag color="purple">Timeout</Tag>;
-        break;
-      case DNFType.Medical:
-        tag = <Tag color="red">Medical</Tag>;
-        break;
-      case DNFType.Unknown:
-        tag = <Tag color="gray">Unknown</Tag>;
-        break;
-      case DNFType.None:
-      default:
-        tag = <> </>;
-        break;
-    }
-  }
-  if (dns) {
-    tag = <Tag color="blue">DNS</Tag>;
-  }
-
-  return tag;
-};
 
 export function RunnerEntry() {
   const { data: runnerData } = useRunnerData();
@@ -70,7 +38,7 @@ export function RunnerEntry() {
     {
       field: "dnfType",
       name: "Status",
-      render: (dnfType, { dns }) => renderStatusTag(dnfType!, dns!),
+      render: (dnfType, { dns }) => <StatusTag dnfType={dnfType} dns={dns} />,
       valueFn: (data) =>
         `${data.dnfType! === DNFType.None ? "" : data.dnfType + "dnf"},
          ${data.dns! ? "DNS" : ""}`,

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -1,8 +1,8 @@
-import { Stack, Tag } from "~/components";
+import { Stack } from "~/components";
 import { StatusTag } from "~/components/StatusTag";
 import { ColumnDef, DataGrid } from "~/features/DataGrid";
 import { formatDate } from "~/lib/datetimes";
-import { DNFType } from "$shared/enums";
+import { DNFType, RecordStatus } from "$shared/enums";
 import { EditRunner } from "./EditRunner";
 import { RunnerFormStats } from "./RunnerFormStats";
 import { RunnerEx, useRunnerData } from "../../hooks/data/useRunnerData";
@@ -38,7 +38,9 @@ export function RunnerEntry() {
     {
       field: "dnfType",
       name: "Status",
-      render: (dnfType, { dns }) => <StatusTag dnfType={dnfType} dns={dns} />,
+      render: (dnfType, { dns, status }) => (
+        <StatusTag dnfType={dnfType} dns={dns} duplicate={status === RecordStatus.Duplicate} />
+      ),
       valueFn: (data) =>
         `${data.dnfType! === DNFType.None ? "" : data.dnfType + "dnf"},
          ${data.dns! ? "DNS" : ""}`,

--- a/src/renderer/src/features/SettingsPage/SettingsPage.tsx
+++ b/src/renderer/src/features/SettingsPage/SettingsPage.tsx
@@ -5,7 +5,7 @@ import { useRFIDStatus } from "./hooks/useRFIDStatus";
 import { useSettingsMutations } from "./hooks/useSettingsMutations";
 import { DeviceStatus } from "../../../../shared/enums";
 
-function useIsStartLine() {
+function useShouldEnableRFID() {
   const { data: startline } = useStoreValue("event.startline");
   const { data: finishline } = useStoreValue("event.finishline");
   const { data: stationIdentifier } = useStoreValue("station.identifier");
@@ -20,7 +20,7 @@ export function SettingsPage() {
   const [recreateOpen, setRecreateOpen] = useState(false);
   const [recoverOpen, setRecoverOpen] = useState(false);
 
-  const isStartLine = useIsStartLine();
+  const shouldEnableRFID = useShouldEnableRFID();
   const [rfidStatus] = useRFIDStatus();
 
   const handleRfidButtonClick = () => {
@@ -64,7 +64,11 @@ export function SettingsPage() {
               </Stack>
             }
           >
-            <Button size="wide" onClick={() => handleRfidButtonClick()} disabled={!isStartLine}>
+            <Button
+              size="wide"
+              onClick={() => handleRfidButtonClick()}
+              disabled={!shouldEnableRFID}
+            >
               {rfidButtonText}
             </Button>
           </VerticalButtonGroup>

--- a/src/renderer/src/hooks/data/useRunnerData.tsx
+++ b/src/renderer/src/hooks/data/useRunnerData.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { DNFType } from "$shared/enums";
+import { DNFType, RecordStatus } from "$shared/enums";
 import { RunnerAthleteDB } from "$shared/models";
 import { DatabaseResponse } from "$shared/types";
 import { useHandleStatusToasts } from "../useHandleStatusToasts";
@@ -18,6 +18,7 @@ export interface RunnerEx extends Runner {
   dns: boolean;
   dnf: boolean;
   dnfType: DNFType;
+  status: RecordStatus;
 }
 
 export function useRunnerData() {
@@ -43,7 +44,8 @@ export function useRunnerData() {
         note: runner.note,
         dns: runner.dns ?? false,
         dnf: runner.dnf ?? false,
-        dnfType: runner.dnfType ?? DNFType.None
+        dnfType: runner.dnfType ?? DNFType.None,
+        status: runner.status ?? RecordStatus.OK
       }));
     }
   });


### PR DESCRIPTION
### Changelog
#### Features
- Render DNS, DNF, and Duplicate status on Runner Entry page
- Truncate boolean prop in Datagrid column definitions
#### Fixes
- Fix some padding issues on the Runner Entry page
#### Chores
- Rename useIsStartLine to useShouldEnableRFID
- Refactor dns/dnf tags on Roster and Runner Entry pages