### PR TITLE
fix: invalidate stats table when RFID entry is made

### DIFF
--- a/src/renderer/src/hooks/ipc/useInvalidateRunnersOnRFID.tsx
+++ b/src/renderer/src/hooks/ipc/useInvalidateRunnersOnRFID.tsx
@@ -9,6 +9,7 @@ export function useInvalidateRunnersOnRFID() {
   useEffect(() => {
     const handleRFIDRead = () => {
       queryClient.invalidateQueries({ queryKey: ["runners-table"] });
+      queryClient.invalidateQueries({ queryKey: ["stats-table"] });
     };
 
     ipcRenderer.on("read-rfid", handleRFIDRead);


### PR DESCRIPTION
##Change log
### Fixes
* fixed missing invalidation hook for stats table on rfid entry