### PR TITLE
Disable mousewheel on bib number entry

### DIFF
--- a/src/renderer/src/features/RunnerEntry/RunnerFormStats.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerFormStats.tsx
@@ -85,6 +85,7 @@ export function RunnerFormStats() {
         ref={inputRef}
         onKeyDown={handleKeyboardShortcuts}
         onChange={handleChange}
+        onWheel={(event) => event.currentTarget.blur()}
         className="h-32 text-8xl text-center border-component"
         placeholder="BIB#"
         type="number"


### PR DESCRIPTION
## Changelog
### Fixes
* Fixed #201
  * Overrode default Chromium behavior and disable mousewheel on bibnumber TextField