### PR TITLE
fix: stop leaking resize listeners in useTruncated

### DIFF
--- a/src/renderer/src/hooks/dom/useTruncated.tsx
+++ b/src/renderer/src/hooks/dom/useTruncated.tsx
@@ -1,8 +1,5 @@
 import { ReactNode, useLayoutEffect, useRef, useState } from "react";
 
-// TODO: seems to be spawning thousands of listeners when scrolling datagrids,
-// one per cell per update, might be removing them just as quickly,
-// but seems to be the cause of a lot of performance/memory churn
 export function useTruncated<T extends HTMLElement>(content: ReactNode) {
   const ref = useRef<T | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
@@ -14,7 +11,7 @@ export function useTruncated<T extends HTMLElement>(content: ReactNode) {
     const findTruncated = () => setIsTruncated(Boolean(el) && el.scrollWidth > el.clientWidth);
 
     findTruncated();
-    window.addEventListener("resize", () => findTruncated());
+    window.addEventListener("resize", findTruncated);
     return () => window.removeEventListener("resize", findTruncated);
   }, [content]);
 


### PR DESCRIPTION
## Summary
Fixes #242.

`useTruncated` (used by every `DataGrid` cell to detect text overflow for tooltips) added a `window` `resize` listener as an inline anonymous function, but its cleanup removed a different function reference (`findTruncated`). `removeEventListener` never matched, so the listener was never actually removed.

The effect re-runs on every cell content change, which happens continuously as `@tanstack/react-virtual` recycles rows during scrolling. Over hours of continuous scrolling in the DataGrid (Roster/Logs/Stats pages), this accumulated thousands of permanently-leaked `resize` listeners, each retaining a closure over a DOM cell element and preventing garbage collection — matching the reported progressive scroll/render slowdown.

## Fix
Reuse the same `findTruncated` function reference for both `addEventListener` and `removeEventListener` so listeners are properly cleaned up on every cell recycle/unmount.

## Validation
- `pnpm exec eslint src/renderer/src/hooks/dom/useTruncated.tsx` — passes clean.
