### PR TITLE
fix: reset ost push status when applying timing edits

### DIFF
--- a/src/main/database/status-db.ts
+++ b/src/main/database/status-db.ts
@@ -3,9 +3,11 @@ import { finished } from "stream/promises";
 import { parse } from "csv-parse";
 import { getDatabaseConnection } from "./connect-db";
 import { logEvent } from "./eventLogger-db";
+import { clearPushStatus } from "./opensplittimeStatus-db";
 import { AthleteProgress, DNFType, DatabaseStatus } from "../../shared/enums";
 import { DNFRecord, DNSRecord, RunnerDB, StatusDB } from "../../shared/models";
 import { DatabaseResponse } from "../../shared/types";
+import { emitRunnersTableChanged } from "../ipc/runner-data-emitter";
 import { sendToastToRenderer } from "../ipc/toast-ipc";
 import * as dialogs from "../lib/file-dialogs";
 import { appStore } from "../lib/store";
@@ -264,8 +266,7 @@ export function SetDNF(
   let dnf: DNFType | null = dnfType;
   const dnfDateTime = !timeOut ? new Date().toISOString() : timeOut.toISOString();
   const timingRecord = db.prepare(`SELECT * FROM TimeRecords WHERE bibId = ?`).get(bibId) as
-    | RunnerDB
-    | undefined;
+    RunnerDB | undefined;
   const previousDnf = db.prepare(`SELECT dnf FROM Status WHERE bibId = ?`).get(bibId) as
     | {
         dnf: number;
@@ -303,6 +304,15 @@ export function SetDNF(
   message = `status:update bibId: ${bibId}, dnf: ${dnfValue}, dnfType: ${dnfType}`;
 
   if (timingRecord && previousDnf?.dnf !== Number(dnfValue)) {
+    // Clear the prior push outcome immediately so the UI shows "Pending" even if the push
+    // below is skipped (paused/not signed in) or takes a while to resolve.
+    db.prepare(`UPDATE TimeRecords SET sent = ? WHERE "bibId" = ?`).run(
+      Number(false),
+      timingRecord.bibId
+    );
+    clearPushStatus(bibId);
+    emitRunnersTableChanged();
+
     void pushTimeRecordUpdate(timingRecord, dnfValue)
       .then((outcome) => {
         if (outcome.pushed) {

--- a/src/main/database/timingRecords-db.ts
+++ b/src/main/database/timingRecords-db.ts
@@ -5,6 +5,7 @@ import { clearPushStatus } from "./opensplittimeStatus-db";
 import * as dbStatus from "./status-db";
 import { DatabaseStatus, EntryMode, RecordStatus, RecordType } from "../../shared/enums";
 import { RunnerDB } from "../../shared/models";
+import { emitRunnersTableChanged } from "../ipc/runner-data-emitter";
 import { appStore } from "../lib/store";
 import { pushTimeRecordUpdate } from "../services/opensplittime";
 
@@ -212,6 +213,21 @@ function updateTimeRecord(
   preserveOrMergeTimes(merge, existingRecord, record);
   processDuplicate(record);
 
+  const timeValue = (time: Date | null): number | null =>
+    time == null ? null : new Date(time).getTime();
+
+  // A duplicate's fractional bib (e.g. 150.2) floors to the original bib number when pushed, so
+  // pushing here would incorrectly overwrite the original runner's time on OST.
+  const shouldPush =
+    record.status !== RecordStatus.Duplicate &&
+    (existingRecord.bibId !== record.bibId ||
+      timeValue(existingRecord.timeIn) !== timeValue(record.timeIn) ||
+      timeValue(existingRecord.timeOut) !== timeValue(record.timeOut));
+
+  // Edited values invalidate whatever was already pushed, so force sent=false rather than
+  // trusting the stale "sent" flag carried over from the renderer's original record.
+  if (shouldPush) record.sent = false;
+
   //build the time record
   const stationID = stationId;
   const timeInISO = record.timeIn == null ? null : record.timeIn.toISOString();
@@ -273,17 +289,13 @@ function updateTimeRecord(
   );
 
   const message = `timing-record:update ${record.bibId}, ${timeInISO}, ${timeOutISO}, ${modifiedISO}, '${record.note}'`;
-  const timeValue = (time: Date | null): number | null =>
-    time == null ? null : new Date(time).getTime();
 
-  // A duplicate's fractional bib (e.g. 150.2) floors to the original bib number when pushed, so
-  // pushing here would incorrectly overwrite the original runner's time on OST.
-  if (
-    record.status !== RecordStatus.Duplicate &&
-    (existingRecord.bibId !== record.bibId ||
-      timeValue(existingRecord.timeIn) !== timeValue(record.timeIn) ||
-      timeValue(existingRecord.timeOut) !== timeValue(record.timeOut))
-  ) {
+  if (shouldPush) {
+    // Clear the prior push outcome immediately so the UI shows "Pending" even if the push
+    // below is skipped (paused/not signed in) or takes a while to resolve.
+    clearPushStatus(record.bibId);
+    emitRunnersTableChanged();
+
     void pushTimeRecordUpdate(record, dbStatus.getStoppedHereForBib(record.bibId))
       .then((outcome) => {
         if (outcome.pushed) markTimeRecordAsSent(record.bibId, true);


### PR DESCRIPTION
## Summary
Editing a runner's timing record (in/out time, or marking DNF) and clicking Apply left the stale sent flag and the prior OpenSplitTime (OST) push status untouched, so the UI kept showing "Uploaded" (or a stale error) instead of "Pending" while the new push resolved. This was most noticeable when OST pushes are paused (e.g. app just started, not yet signed in to OST), since the push is skipped entirely and never resolves to update the status.

## Changes
- **timingRecords-db.ts**: hoisted the existing push-trigger condition in `updateTimeRecord()` into a `shouldPush` boolean computed before the `sent` column value is read; when true, forces `record.sent = false` (instead of trusting the incoming stale value) and synchronously clears the prior push status (`clearPushStatus`) and notifies the renderer (`emitRunnersTableChanged`) before firing the async `pushTimeRecordUpdate`.
- **status-db.ts**: in `SetDNF()`, when a DNF value change triggers a re-push, resets `TimeRecords.sent` to 0, clears the prior push status, and emits the table-changed event before firing the async push.
- Both resets happen unconditionally and synchronously, before the async push (and before its internal `pushPaused` short-circuit), so the "Pending" state is shown immediately regardless of whether the push is currently paused/skipped, succeeds, or fails.

## Testing
- `pnpm exec eslint src/main/database/timingRecords-db.ts src/main/database/status-db.ts` — passes clean
- `pnpm run typecheck:node` — passes clean
- Manual testing confirming the new behavior, including the paused-push scenario