### PR TITLE
fix(import): preserve dnf station data from csv

### DIFF
--- a/src/main/database/status-db.ts
+++ b/src/main/database/status-db.ts
@@ -65,7 +65,7 @@ export async function LoadDNF() {
       const stationId = appStore.get("station.id") as number;
 
       if (dnfStationId <= stationId) {
-        updateDNFFromCSV(row);
+        updateDNFFromCSV({ ...row, stationIdentifier: row.stationId });
         dnfCount++;
       }
     })


### PR DESCRIPTION
## Summary
Fixes #229. Preserve the station identifier when importing DNF records from CSV so imported DNF station data is retained correctly.

## Changes
- **CSV import**: map parsed `stationId` values to the `stationIdentifier` field required by `updateDNFFromCSV`.

## Testing
- Not applicable: commit-only workflow; existing validation was run before this PR workflow.