### PR TITLE
fix: prevent toast leaks and harden dnf export

### DIFF
--- a/src/main/database/runners-db.ts
+++ b/src/main/database/runners-db.ts
@@ -428,18 +428,19 @@ export async function exportDNFAsCSV() {
   const db = getDatabaseConnection();
   let queryResult;
   let filename: string = "";
-  const stationIdentifier = appStore.get("station.identifier") as number;
+  const stationId = appStore.get("station.id") as number;
 
   const stmt = `
-    SELECT t1.dnf, t1.dnfType, t1.dnfStation, t1.dnfDateTime, t2.*
-    FROM Status t1 INNER JOIN TimeRecords t2
+    SELECT t1.bibId AS dnfBibId, t1.dnf, t1.dnfType, t1.dnfStation, t1.dnfDateTime, t2.*
+    FROM Status t1 LEFT JOIN TimeRecords t2
     ON t1.bibId = t2.bibId
     WHERE t1.dnf == 1
-    AND t1.dnfStation == ?
   `;
 
   try {
-    queryResult = db.prepare(stmt).all(stationIdentifier);
+    const dnfRows = db.prepare(stmt).all() as DNFExportRow[];
+    queryResult = dnfRows
+      .filter((row) => Number(String(row.dnfStation).split("-", 1)[0]) <= stationId);
     filename = await dialogs.saveDNFRunnersToCSV();
 
     if (filename == undefined) return "Invalid file name";
@@ -499,6 +500,14 @@ interface DNFRunnerDB extends RunnerDB {
   dnfDateTime: Date | null;
 }
 
+interface DNFExportRow extends DNFRunnerDB {
+  dnfBibId: number;
+}
+
+function normalizeExportNote(note: string | null | undefined): string {
+  return note ?? "";
+}
+
 function writeDNSToCSV(filename: string, queryResult) {
   const fs = require("fs");
   const eventName = appStore.get("event.name") as string;
@@ -525,7 +534,7 @@ function writeDNSToCSV(filename: string, queryResult) {
         `${startLineIdentifier},` +
         `${row.bibId},` +
         `${eventStartTime == null ? "" : eventStartTime},` +
-        `${row.note}`;
+        `${normalizeExportNote(row.note)}`;
       stream.write(rowText + "\n");
     }
     stream.on("error", reject);
@@ -551,14 +560,14 @@ function writeDNFToCSV(filename: string, queryResult) {
     const rowText = `${columnNames[0]},${columnNames[1]},${columnNames[2]},${columnNames[3]},${columnNames[4]}`;
     stream.write(rowText + "\n");
 
-    for (const row of queryResult as DNFRunnerDB[]) {
+    for (const row of queryResult as DNFExportRow[]) {
       let rowText = "";
       rowText =
         `${row.dnfStation},` +
-        `${row.bibId},` +
+        `${row.dnfBibId},` +
         `${row.dnfType},` +
         `${row.dnfDateTime == null ? "" : formatDate(row.dnfDateTime)},` +
-        `${row.note}`;
+        `${normalizeExportNote(row.note)}`;
       stream.write(rowText + "\n");
     }
     stream.on("error", reject);

--- a/src/renderer/src/features/Toasts/ToastsProvider.tsx
+++ b/src/renderer/src/features/Toasts/ToastsProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useCallback, useEffect, useState } from "react";
 import { compareAsc } from "date-fns";
 import { createPortal } from "react-dom";
 import { v4 as uuid } from "uuid";
@@ -14,9 +14,15 @@ function useMainToastListener(createToast: (toast: Toast) => void) {
   const ipcRenderer = useIpcRenderer();
 
   useEffect(() => {
-    ipcRenderer.on("create-toast", (_event, toast: Toast) => {
+    const listener = (_event: unknown, toast: Toast) => {
       createToast(toast);
-    });
+    };
+
+    ipcRenderer.on("create-toast", listener);
+
+    return () => {
+      ipcRenderer.off("create-toast", listener);
+    };
   }, [createToast, ipcRenderer]);
 }
 
@@ -25,9 +31,9 @@ export function ToastProvider(props: { children: ReactNode }) {
 
   const [toasts, setToasts] = useState<InternalToast[]>([]);
 
-  const createToast = (toast: Toast) => {
-    setToasts([
-      ...toasts,
+  const createToast = useCallback((toast: Toast) => {
+    setToasts((prev) => [
+      ...prev,
       {
         ...toast,
         id: uuid(),
@@ -35,7 +41,7 @@ export function ToastProvider(props: { children: ReactNode }) {
         timeoutMs: toast.timeoutMs ?? DEFAULT_TIMEOUT
       }
     ]);
-  };
+  }, []);
 
   useMainToastListener(createToast);
 


### PR DESCRIPTION
## Summary
Prevent toast IPC listener leaks and harden DNF export persistence so station-scoped exports retain prior/current records, include status-only imported DNFs, preserve the correct bib ID, and emit blank notes when notes are missing.

## Changes
- **Toast notifications**: remove the IPC listener leak in the toast provider.
- **DNF export**: include prior/current station records and status-only imported DNFs with a `LEFT JOIN`.
- **Export fields**: use `Status.bibId` for DNF bib IDs and serialize missing notes as blank fields.

## Testing
- `pnpm run build` — passes clean.
- `git diff --check` — passes clean.