### PR TITLE
feat: add export status indicators and tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 ![image](https://github.com/user-attachments/assets/f1d4e7a5-e90b-471c-9137-1f1022d9e1f9)
 
 An app for tracking athletes during ultra marathons.
@@ -8,10 +7,12 @@ An Electron application with React and TypeScript for Windows, Linux, and MacOS.
 For a guide on how to set up an event using Ultra-Tracker, visit the project [Wiki](https://github.com/barcradio/ultra-tracker/wiki).
 
 ---
+
 ## Initial Setup
+
 <img width="224" height="48" alt="image" src="https://github.com/user-attachments/assets/edb8ef37-8053-40b0-abf4-f2e8859d86be" />
 
-1. Copy the event files into the event-configs folder:  
+1. Copy the event files into the event-configs folder:
    1. `\Documents\Ultra-Tracker\.event-config\`
 2. Load the Stations file
    1. Select Station location and set operator call sign
@@ -21,40 +22,45 @@ For a guide on how to set up an event using Ultra-Tracker, visit the project [Wi
 6. Go to stats screen and begin logging athletes
 
 ## Navigation Sidebar
-The left side bar is used to select different pages.  Select from Stats, Roster, Logs, Export, Theme, Database, Settings and Help. Hovering over the sidebar area will expand it to show the names.
+
+The left side bar is used to select different pages. Select from Stats, Roster, Logs, Export, Theme, Database, Settings and Help. Hovering over the sidebar area will expand it to show the names.
 
 ## Stats Page
+
 <img alt="image" src="https://github.com/user-attachments/assets/c4eb6caf-7fbf-42e5-a8b2-bc8f34986fd3" />
 
-The **BIB#** box is the main starting point for using this page. This input control will accept numerical input, either from the 10-key pad or top-row keys of all standard keyboards.  See useful keyboard shortcuts below.
+The **BIB#** box is the main starting point for using this page. This input control will accept numerical input, either from the 10-key pad or top-row keys of all standard keyboards. See useful keyboard shortcuts below.
 
 Clicking the In button and Out button will record the corresponding time entry.
 
-The datagrid columns can be Sorted by clicking on the column header.  Click again to toggle Ascending or Descending Sort. 
+The datagrid columns can be Sorted by clicking on the column header. Click again to toggle Ascending or Descending Sort.
 
 A Filter control for any column can be opened by clicking the Filter icon (three vertical dots).
 
 > [!WARNING]
-> If the horizontal width of the Ultra-Tracker window is too small, the column filter buttons can overlap the column headers and cause the Sort and Filter features difficult to use.  The default layout has been carefully adjusted for modern HD resolutions but display scaling or screen resolution settings in the operating system can make the display too small to fit the default size of Ultra-Tracker.  Adjusting these settings will resolve this on most computers.
+> If the horizontal width of the Ultra-Tracker window is too small, the column filter buttons can overlap the column headers and cause the Sort and Filter features difficult to use. The default layout has been carefully adjusted for modern HD resolutions but display scaling or screen resolution settings in the operating system can make the display too small to fit the default size of Ultra-Tracker. Adjusting these settings will resolve this on most computers.
 
 ### Editing a record
+
 <img width="350" alt="image" src="https://github.com/user-attachments/assets/d81b847b-f2f5-4c99-98e0-0b84d1112be2" />
 
 To edit a timing record, click on the icon at the far-right side of the record row.
 
-The Edit pane allows modification or deletion of a timing record.  The In and Out times, DNF and DNS status, and any notes that have been entered will be displayed.  Changes to these fields must be applied to take effect, or cancelled to return to the Stats page.
+The Edit pane allows modification or deletion of a timing record. The In and Out times, DNF and DNS status, and any notes that have been entered will be displayed. Changes to these fields must be applied to take effect, or cancelled to return to the Stats page.
 
-If the Bib# can be matched with known athlete, the athlete's name will be displayed.  The button above the name will jump to that athlete in the Roster page.  A timing record for an unknown athlete is considered a warning condition, as all athletes should be known and checked in at the Start of the event, and included in the Athletes file. For a timing record not matched to athlete, limited changes can be performed, resolve the Bib# to a known athlete to modify all values.
+If the Bib# can be matched with known athlete, the athlete's name will be displayed. The button above the name will jump to that athlete in the Roster page. A timing record for an unknown athlete is considered a warning condition, as all athletes should be known and checked in at the Start of the event, and included in the Athletes file. For a timing record not matched to athlete, limited changes can be performed, resolve the Bib# to a known athlete to modify all values.
 
 > [!CAUTION]
 > Deleting a time record is permanent. An entry to the Log page is recorded for reference.
 
-Validation Rules: 
-* A record must have an In time.
-* An In time must occur before the Out time.
-* Commas are not allowed in the Note field, and will be replaced with semi-colons.
+Validation Rules:
+
+- A record must have an In time.
+- An In time must occur before the Out time.
+- Commas are not allowed in the Note field, and will be replaced with semi-colons.
 
 ### Athlete and Station stats
+
 <img width="266" height="431" alt="image" src="https://github.com/user-attachments/assets/df03ef51-32fd-4e44-9e74-363c35a71318" />
 
 Each of the different statistics available are updated in real-time.
@@ -66,9 +72,10 @@ Each of the different statistics available are updated in real-time.
 > Errors should be resolved before sending data to race organizers.
 
 ### Keyboard shortcuts
+
 Entry of numbers and times is assisted by using some specific keys on both an 88 key (or more) keyboard or a 10-key Numpad. When the cursor is focused in the **Bib#** box, entering a bib number and pressing one of these keys will automatically enter the record and populate the corresponding time.
 
-*10-key entry is recommended for all stations, for laptops without, use a USB 10-key peripheral.*
+_10-key entry is recommended for all stations, for laptops without, use a USB 10-key peripheral._
 
 > | <div style="width:150px;fontSize:larger">**In**</div> | <div style="width:150px;fontSize:larger">**Out**</div> | <div style="width:150px;fontSize:larger">**In and Out**</div> |
 > | :------------- | :---------------- | :-------------- |
@@ -79,22 +86,24 @@ Entry of numbers and times is assisted by using some specific keys on both an 88
 
 <img alt="image" src="https://github.com/user-attachments/assets/7a1fee59-e37a-47c4-b3ff-12fd2315c35e" />
 
-
 ## Roster Page
+
 <img width="224" height="48" alt="image" src="https://github.com/user-attachments/assets/e9a99652-e365-43c4-8b86-b025ba020ecb" />
 
 This page provides the list of all athletes and enable the operator to search for an athlete using different search keys, such as, name, bib number, city, start time, Station TimeIn, Station TimeOut and note entries.
 
-The Status column helps station operators determine which athletes are pertinent to the station.  Valid filter options for the Status column are: `Incoming, DNS, In, Out, Medical, Timeout, Withdrew`
+The Status column helps station operators determine which athletes are pertinent to the station. Valid filter options for the Status column are: `Incoming, DNS, In, Out, Medical, Timeout, Withdrew`
 
 ## Stations Page
+
 <img width="210" height="46" alt="image" src="https://github.com/user-attachments/assets/0ad0ad0c-40a8-47c4-97f5-ace3e1178685" />
 
-This page is used to select the Station name and operator callsign.  The callsign selection is currently superficial, and is populated by the metadata in the Stations file and cannot be modified during an event.
+This page is used to select the Station name and operator callsign. The callsign selection is currently superficial, and is populated by the metadata in the Stations file and cannot be modified during an event.
 
 This page also shows the details about the aid stations throughout the race, location, mileage, cutoff times.
 
 ## Logs Page
+
 <img width="231" height="51" alt="image" src="https://github.com/user-attachments/assets/956162cf-1195-40ff-9124-37b872e25c85" />
 
 This page displays the station log file that is auto-generated during station operation. There are two versions of the log that can be viewed and/or exported for the use of operators or developers to aid in fixing errors that may occur due to programming mistakes or unforeseen situations.
@@ -103,89 +112,102 @@ This page displays the station log file that is auto-generated during station op
 - The verbose station log is a saved file that contains all events that occurred as well as debug messages designed to assist Ultra-Tracker developers to locate problems that occur during an event. This can be large and should be sent to the developers only upon request.
 
 ## Export Page
+
 <img width="218" height="50" alt="image" src="https://github.com/user-attachments/assets/b939c800-1a9f-4b81-9e2a-f44c87111278" />
 
-This page provides Export utilities for sending station data to another station or race organizers.  These file formats are optimized for human and machine readability.
+This page provides Export utilities for sending station data to another station or race organizers. These file formats are optimized for human and machine readability.
+
+When OpenSplitTime is not signed in, the indicator at the left of each timing record shows its CSV export state: a gray hollow circle means the record has not been exported, and a green hollow circle means it has been exported. A successful incremental or full CSV export marks its included records as exported.
 
 - **Export Incremental CSV File**
-This function exports a `.csv` file of the station entries containing unsent or edited records, contains BibID, TimeIn, TimeOut, DNF/DNS status and any notes made by the operator.  The exported file will be automatically named and  incremented. e.g. `Aid05Times_04i.csv, Aid05Times_05i.csv, and Aid05Times_06i.csv`.
+  This function exports a `.csv` file of the station entries containing unsent or edited records, contains BibID, TimeIn, TimeOut, DNF/DNS status and any notes made by the operator. The exported file will be automatically named and incremented. e.g. `Aid05Times_04i.csv, Aid05Times_05i.csv, and Aid05Times_06i.csv`.
 
-  Sending recent time records in smaller batches allows for much smaller files being routinely sent to race leadership to import to the race timing site, whether by packet radio or internet. This keeps timing data updated timely for athlete support crews and other situation in an event.  Depending on the rate of athletes arriving and departing a station, sending an incremental file _every 30 minutes at a minimim_ is recommended, more often if possible.
-  
-  A station setup with a data entry PC networked to a data transmission PC is recommended so interruption of data entry is limited to a quick Incremental Export operation.  This allows the data transmission operator to access the exported files independently.
+  Sending recent time records in smaller batches allows for much smaller files being routinely sent to race leadership to import to the race timing site, whether by packet radio or internet. This keeps timing data updated timely for athlete support crews and other situation in an event. Depending on the rate of athletes arriving and departing a station, sending an incremental file _every 30 minutes at a minimim_ is recommended, more often if possible.
+
+  A station setup with a data entry PC networked to a data transmission PC is recommended so interruption of data entry is limited to a quick Incremental Export operation. This allows the data transmission operator to access the exported files independently.
 
   > [!CAUTION]
   > All Incremental files must be transmitted to the race leadership as each file only contains a portion of the overall station data.
-  
 
 - **Export Full CSV File**
-This function exports a full `.csv` file of **all time records** containing TimeIn, TimeOut, DNF/DNS status and any notes made by the station operators.
+  This function exports a full `.csv` file of **all time records** containing TimeIn, TimeOut, DNF/DNS status and any notes made by the station operators.
 
 This file is useful as a final station report.
 
 - **Export DNS File**
-This function exports a `.csv` file with all DNS entries that have occurred at the current station.  This is unlikely to be used at any station other than the Start Line.
+  This function exports a `.csv` file with all DNS entries that have occurred at the current station. This is unlikely to be used at any station other than the Start Line.
 
 - **Export DNF File**
-This function exports a `.csv` file with all DNF entries that have occurred up to the current station.  This file is not normally needed to be sent to race organizers but can be an efficient way of sending the current station's DNF list to another station.
-
+  This function exports a `.csv` file with all DNF entries that have occurred up to the current station. This file is not normally needed to be sent to race organizers but can be an efficient way of sending the current station's DNF list to another station.
 
 ## Theme Page
+
 <img width="224" height="48" alt="image" src="https://github.com/user-attachments/assets/37b36db6-84dd-468c-8b0d-baa48a44e133" />
 
 This is a global selection that allows two different color/shading options for use during daylight or nighttime station operation.
 
-
 ## Settings Page
+
 <img width="224" height="48" alt="image" src="https://github.com/user-attachments/assets/e0ec7fdb-b0aa-4218-8acd-8b7daf12a637" />
 
 This page allows the operator to manage various input files and the database needed for proper station operation. Event files are loaded and saved from the user's Documents directory (per operating system). File Load/Export dialogs will open here and this directory can be opened quickly via the button provided on the Export page.
 
-  * Windows: `%userprofile%\Documents\ultra-tracker\`
-  * Linux: `$HOME/Documents/ultra-tracker`
-  * MacOS:  `/Users/username/Documents/ultra-tracker`
+- Windows: `%userprofile%\Documents\ultra-tracker\`
+- Linux: `$HOME/Documents/ultra-tracker`
+- MacOS: `/Users/username/Documents/ultra-tracker`
+
+### OpenSplitTime
+
+OpenSplitTime is an optional integration for sending timing records directly to the selected event group. Configure the event group in the Stations file, then sign in on the Settings page with an OpenSplitTime steward account. Credentials may be saved using the operating system's secure credential storage. If both staging and production event groups are configured, select the environment before signing in. Production sends times to the live event and requires confirmation when switching from staging.
+
+While signed in, OpenSplitTime status takes precedence over CSV export status in the timing-record indicator: yellow means pending upload, solid green means uploaded, and red means upload failed. Use Pause Pushes to temporarily stop automatic uploads without signing out; Resume Pushes restarts them. Sign Out returns the indicator to the CSV export state and does not change whether a record has been exported.
 
 > [!CAUTION]
-> The functions marked in RED on the Settings page are completely destructive to the local database and **MUST NOT be performed during normal operation!**  These are provided only for recovery of the database or data and should only be used at the direction of the software team.
+> The functions marked in RED on the Settings page are completely destructive to the local database and **MUST NOT be performed during normal operation!** These are provided only for recovery of the database or data and should only be used at the direction of the software team.
 
 > [!WARNING]
 > The functions in ORANGE are provided as a means to completely recover after a major database error and other methods have not corrected the issue.
 
-The following is a description of each button's function.  Each of these will open a file open dialog to the `\Documents\Ultra-Tracker\.event-config\` directory.
+The following is a description of each button's function. Each of these will open a file open dialog to the `\Documents\Ultra-Tracker\.event-config\` directory.
 
 #### Station Setup
-* **Load Stations File**
-This loads a `JSON` file containing each of the stations and their detailed information to allow ease of selection while setting up this application. A typical filename will be `eventname-YYYY-stations.json`.
-* **Load Athletes File**  
-This function loads a `.csv` file, supplied by race organizers, containing all athletes registered or checked in for the event, whether they are known to have started _or not_.
-* **Load DNS File**
-This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** the race.
-* **Load DNF File**
-This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not finished** the race.
+
+- **Load Stations File**
+  This loads a `JSON` file containing each of the stations and their detailed information to allow ease of selection while setting up this application. A typical filename will be `eventname-YYYY-stations.json`.
+- **Load Athletes File**  
+  This function loads a `.csv` file, supplied by race organizers, containing all athletes registered or checked in for the event, whether they are known to have started _or not_.
+- **Load DNS File**
+  This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** the race.
+- **Load DNF File**
+  This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not finished** the race.
 
   As an event proceeds more DNF athletes will be recorded and new DNF files will be supplied to stations.
 
-  Importing new DNF files will update all athletes recorded and DNF earlier in the race, DNFs past the current station are ignored.  This provides insight of which athletes are still expected into the current station.
+  Importing new DNF files will update all athletes recorded and DNF earlier in the race, DNFs past the current station are ignored. This provides insight of which athletes are still expected into the current station.
 
 #### RFID Configuration
-* **Initialize RFID**
-Starts and stops a RFID reader service for the Zebra FXR90 hardware.  These controls are enabled only for Start and Finish Line stations only.  Integrations with more RFID hardware will be possible in the future.
+
+- **Initialize RFID**
+  Starts and stops a RFID reader service for the Zebra FXR90 hardware. These controls are enabled only for Start and Finish Line stations only. Integrations with more RFID hardware will be possible in the future.
 
 #### Application Settings
-* **Reset App Settings** 
-This will reset the local application settings file to defaults.  This can be useful for recovering from an unexpected error.
-The application settings file `config.json` is located at:
-  * Windows: `%appdata%\ultra-tracker`
-  * Linux: `~/.config/ultra-tracker`
-  * MacOS:  `~/Library/Application Support/ultra-tracker`
+
+- **Reset App Settings**
+  This will reset the local application settings file to defaults. This can be useful for recovering from an unexpected error.
+  The application settings file `config.json` is located at:
+  - Windows: `%appdata%\ultra-tracker`
+  - Linux: `~/.config/ultra-tracker`
+  - MacOS: `~/Library/Application Support/ultra-tracker`
 
 #### Developer Tools
-* **Recreate Database**
-This function is the means where *ALL* **database entries and tables are removed** resulting in the loss of *ALL* setup data and entry history!  The intent is to allow recovery of a major database corruption event and the rapid rebuild and subsequent return to normal operation by the operator.
-* **Recover Data From CSV File**
-This function imports **ALL of the entries** that have previously been made by the operator since the start of this race event!  The Ultra-Tracker application has been automatically producing a file containing EVERY entry made by the operator continuously during normal operation! This function will restore all of this data to restore the program to the previous state automatically.
+
+- **Recreate Database**
+  This function is the means where _ALL_ **database entries and tables are removed** resulting in the loss of _ALL_ setup data and entry history! The intent is to allow recovery of a major database corruption event and the rapid rebuild and subsequent return to normal operation by the operator.
+- **Recover Data From CSV File**
+  This function imports **ALL of the entries** that have previously been made by the operator since the start of this race event! The Ultra-Tracker application has been automatically producing a file containing EVERY entry made by the operator continuously during normal operation! This function will restore all of this data to restore the program to the previous state automatically.
 
 ### Station Recovery Procedure
+
 > [!WARNING]
 > If instructed to do so, after the "Recreate Database" has been performed, perform the following steps:
 >
@@ -196,10 +218,11 @@ This function imports **ALL of the entries** that have previously been made by t
 > 1. Import a Full Export file using "Recover Data From CSV File".
 
 ### Local Database
-Ultra-Tracker runs a modern database on the local machine.  All transactions are preserved immediately and the operator can close and re-open the app without loss of data.  A background task backs up the database to a secondary file, every 5 minutes.  This backup is used for emergency use only and may not restore all data in a data-loss event.  *Do not modify the local database files using external tools!*
 
+Ultra-Tracker runs a modern database on the local machine. All transactions are preserved immediately and the operator can close and re-open the app without loss of data. A background task backs up the database to a secondary file, every 5 minutes. This backup is used for emergency use only and may not restore all data in a data-loss event. _Do not modify the local database files using external tools!_
 
 ## About Ultra-Tracker
+
 A cross-platform desktop application for tracking athletes during ultra marathons.
 This project is supported on Windows, Linux, and MacOS.
 
@@ -210,6 +233,7 @@ Built as an Electron application using TypeScript + React + Tailwind CSS.
 **Releases**: [https://github.com/barcradio/ultra-tracker/releases](https://github.com/barcradio/ultra-tracker/releases)
 
 ## Contributors
+
 > | <div style="width:200px;fontSize:larger">**Name**</div> | <div style="width:100px;fontSize:larger">**Call Sign**</div> | <div style="width:200px;> fontSize:larger">**GitHub**</div> |
 > | :------------------- | :----------- | :----------------------------------------------------- |
 > | **Jaren Glenn**      | ---          | [**@derethil**](https://github.com/derethil)           |
@@ -221,4 +245,5 @@ Built as an Electron application using TypeScript + React + Tailwind CSS.
 > | **Brandon Tibbitts** | KD7IIW       | [**@Tibbs327**](https://github.com/Tibbs327)           |
 
 ## License
+
 [MIT](https://opensource.org/license/mit) ©2025 [Bridgerland Amateur Radio Club](https://barconline.org/)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,15 @@ This page displays the station log file that is auto-generated during station op
 
 This page provides Export utilities for sending station data to another station or race organizers. These file formats are optimized for human and machine readability.
 
-When OpenSplitTime is not signed in, the indicator at the left of each timing record shows its CSV export state: a gray hollow circle means the record has not been exported, and a green hollow circle means it has been exported. A successful incremental or full CSV export marks its included records as exported.
+Timing record indicators show the current delivery state:
+
+| State | Indicator | Meaning |
+| :--- | :--- | :--- |
+| CSV export | <img src="src/renderer/public/img/status/not-exported.svg" alt="Gray hollow circle" width="16"> | Not exported |
+| CSV export | <img src="src/renderer/public/img/status/exported.svg" alt="Green hollow circle" width="16"> | Exported by a successful incremental or full CSV export |
+| OpenSplitTime | <img src="src/renderer/public/img/status/upload-pending.svg" alt="Yellow solid circle" width="16"> | Pending upload |
+| OpenSplitTime | <img src="src/renderer/public/img/status/uploaded.svg" alt="Green solid circle" width="16"> | Uploaded |
+| OpenSplitTime | <img src="src/renderer/public/img/status/upload-failed.svg" alt="Red solid circle" width="16"> | Upload failed |
 
 - **Export Incremental CSV File**
   This function exports a `.csv` file of the station entries containing unsent or edited records, contains BibID, TimeIn, TimeOut, DNF/DNS status and any notes made by the operator. The exported file will be automatically named and incremented. e.g. `Aid05Times_04i.csv, Aid05Times_05i.csv, and Aid05Times_06i.csv`.
@@ -160,7 +168,7 @@ This page allows the operator to manage various input files and the database nee
 
 OpenSplitTime is an optional integration for sending timing records directly to the selected event group. Configure the event group in the Stations file, then sign in on the Settings page with an OpenSplitTime steward account. Credentials may be saved using the operating system's secure credential storage. If both staging and production event groups are configured, select the environment before signing in. Production sends times to the live event and requires confirmation when switching from staging.
 
-While signed in, OpenSplitTime status takes precedence over CSV export status in the timing-record indicator: yellow means pending upload, solid green means uploaded, and red means upload failed. Use Pause Pushes to temporarily stop automatic uploads without signing out; Resume Pushes restarts them. Sign Out returns the indicator to the CSV export state and does not change whether a record has been exported.
+While signed in, OpenSplitTime status takes precedence over CSV export status in the timing-record indicator. Use Pause Pushes to temporarily stop automatic uploads without signing out; Resume Pushes restarts them. Sign Out returns the indicator to the CSV export state and does not change whether a record has been exported.
 
 > [!CAUTION]
 > The functions marked in RED on the Settings page are completely destructive to the local database and **MUST NOT be performed during normal operation!** These are provided only for recovery of the database or data and should only be used at the direction of the software team.
@@ -174,7 +182,7 @@ The following is a description of each button's function. Each of these will ope
 
 - **Load Stations File**
   This loads a `JSON` file containing each of the stations and their detailed information to allow ease of selection while setting up this application. A typical filename will be `eventname-YYYY-stations.json`.
-- **Load Athletes File**  
+- **Load Athletes File**
   This function loads a `.csv` file, supplied by race organizers, containing all athletes registered or checked in for the event, whether they are known to have started _or not_.
 - **Load DNS File**
   This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** the race.

--- a/src/main/database/timingRecords-db.ts
+++ b/src/main/database/timingRecords-db.ts
@@ -284,13 +284,11 @@ function updateTimeRecord(
       timeValue(existingRecord.timeIn) !== timeValue(record.timeIn) ||
       timeValue(existingRecord.timeOut) !== timeValue(record.timeOut))
   ) {
-    void pushTimeRecordUpdate(record, dbStatus.getStoppedHereForBib(record.bibId))
-      .then((outcome) => {
-        if (outcome.pushed) markTimeRecordAsSent(record.bibId, true);
-      })
-      .catch((error: unknown) => {
+    void pushTimeRecordUpdate(record, dbStatus.getStoppedHereForBib(record.bibId)).catch(
+      (error: unknown) => {
         console.error("OpenSplitTime record update failed", error);
-      });
+      }
+    );
   }
 
   if (record.status == RecordStatus.Duplicate) return [DatabaseStatus.Duplicate, message];
@@ -345,13 +343,11 @@ function insertTimeRecord(record: TypedRunnerDB): DatabaseResponse {
   // pushing here would incorrectly overwrite the original runner's time on OST until the operator
   // resolves the duplicate to a real bib number.
   if (record.status !== RecordStatus.Duplicate) {
-    void pushTimeRecordUpdate(record, dbStatus.getStoppedHereForBib(record.bibId))
-      .then((outcome) => {
-        if (outcome.pushed) markTimeRecordAsSent(record.bibId, true);
-      })
-      .catch((error: unknown) => {
+    void pushTimeRecordUpdate(record, dbStatus.getStoppedHereForBib(record.bibId)).catch(
+      (error: unknown) => {
         console.error("OpenSplitTime record update failed", error);
-      });
+      }
+    );
   }
 
   if (record.status == RecordStatus.Duplicate) return [DatabaseStatus.Duplicate, message];

--- a/src/main/ipc/opensplittime-ipc.ts
+++ b/src/main/ipc/opensplittime-ipc.ts
@@ -2,7 +2,7 @@ import { ipcMain } from "electron";
 import { DatabaseStatus } from "../../shared/enums";
 import { RunnerDB } from "../../shared/models";
 import { getStoppedHereForBib } from "../database/status-db";
-import { getTimeRecordbyBib, markTimeRecordAsSent } from "../database/timingRecords-db";
+import { getTimeRecordbyBib } from "../database/timingRecords-db";
 import {
   OpenSplitTimeEnvironment,
   OpenSplitTimeRawTime,
@@ -128,12 +128,9 @@ const pushOpenSplitTimeRecord: Handler<PushRecordParams> = async (_, params) => 
     throw new TypeError(`No timing record found for bib ${params.bibId}`);
   }
 
-  const outcome = await pushTimeRecordUpdate(record, getStoppedHereForBib(record.bibId), {
+  return pushTimeRecordUpdate(record, getStoppedHereForBib(record.bibId), {
     force: true
   });
-  if (outcome.pushed) markTimeRecordAsSent(record.bibId, true);
-
-  return outcome;
 };
 
 export const initOpenSplitTimeHandlers = () => {

--- a/src/renderer/public/img/status/exported.svg
+++ b/src/renderer/public/img/status/exported.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" role="img" aria-label="Exported">
+  <circle cx="8" cy="8" r="6" fill="none" stroke="#0EAA00" stroke-width="2"/>
+</svg>

--- a/src/renderer/public/img/status/not-exported.svg
+++ b/src/renderer/public/img/status/not-exported.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" role="img" aria-label="Not exported">
+  <circle cx="8" cy="8" r="6" fill="none" stroke="#6b7280" stroke-width="2"/>
+</svg>

--- a/src/renderer/public/img/status/upload-failed.svg
+++ b/src/renderer/public/img/status/upload-failed.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" role="img" aria-label="Upload failed">
+  <circle cx="8" cy="8" r="6" fill="#F30707"/>
+</svg>

--- a/src/renderer/public/img/status/upload-pending.svg
+++ b/src/renderer/public/img/status/upload-pending.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" role="img" aria-label="Pending upload">
+  <circle cx="8" cy="8" r="6" fill="#FBBE00"/>
+</svg>

--- a/src/renderer/public/img/status/uploaded.svg
+++ b/src/renderer/public/img/status/uploaded.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" role="img" aria-label="Uploaded">
+  <circle cx="8" cy="8" r="6" fill="#0EAA00"/>
+</svg>

--- a/src/renderer/src/assets/documents/get-started.md
+++ b/src/renderer/src/assets/documents/get-started.md
@@ -104,11 +104,11 @@ Entry of numbers and times is assisted by using some specific keys on both an 88
 _10-key entry is recommended for all stations, for laptops without, use a USB 10-key peripheral._
 
 > | <div style="width:150px;fontSize:larger">**In**</div> | <div style="width:150px;fontSize:larger">**Out**</div> | <div style="width:150px;fontSize:larger">**In and Out**</div> |
-> | :---------------------------------------------------- | :----------------------------------------------------- | :------------------------------------------------------------ |
-> | [Equal]                                               | [Minus]                                                | [Slash]                                                       |
-> | [Enter]                                               | [Numpad-Subtract]                                      | [Backslash]                                                   |
-> | [Numpad-Add]                                          |                                                        | [Numpad-Divide]                                               |
-> | [Numpad-Enter]                                        |                                                        |                                                               |
+> | :------------- | :---------------- | :-------------- |
+> | [Equal]        | [Minus]           | [Slash]         |
+> | [Enter]        | [Numpad-Subtract] | [Backslash]     |
+> | [Numpad-Add]   |                   | [Numpad-Divide] |
+> | [Numpad-Enter] |                   |                 |
 
 ![keyboard-layout.png](./img/keyboard-layout.png)
 
@@ -176,7 +176,15 @@ This page displays the station log file that is auto-generated during station op
 This page provides Export utilities for sending station data to another station or race organizers.  These file formats are optimized for human and machine readability.
 <br/><br/>
 
-When OpenSplitTime is not signed in, the indicator at the left of each timing record shows its CSV export state: a gray hollow circle means the record has not been exported, and a green hollow circle means it has been exported. A successful incremental or full CSV export marks its included records as exported.
+Timing record indicators show the current delivery state:
+
+| <div style="width:150px;fontSize:larger">**State**</div> | <div style="width:150px;fontSize:larger">**Indicator**</div> | <div style="width:340px;fontSize:larger">**Meaning**</div> |
+| :--- | :--- | :--- |
+| CSV export | <img src="./img/status/not-exported.svg" alt="Gray hollow circle" width="16"> | Not exported |
+| CSV export | <img src="./img/status/exported.svg" alt="Green hollow circle" width="16"> | Exported by a successful incremental or full CSV export |
+| OpenSplitTime | <img src="./img/status/upload-pending.svg" alt="Yellow solid circle" width="16"> | Pending upload |
+| OpenSplitTime | <img src="./img/status/uploaded.svg" alt="Green solid circle" width="16"> | Uploaded |
+| OpenSplitTime | <img src="./img/status/upload-failed.svg" alt="Red solid circle" width="16"> | Upload failed |
 
 - **Export Incremental CSV File**
   This function exports a `.csv` file of the station entries containing unsent or edited records, contains BibID, TimeIn, TimeOut, DNF/DNS status and any notes made by the operator. The exported file will be automatically named and incremented. e.g. `Aid05Times_04i.csv, Aid05Times_05i.csv, and Aid05Times_06i.csv`.
@@ -234,7 +242,10 @@ The purpose of this page is to allow the operator to import the various input fi
 
 OpenSplitTime is an optional integration for sending timing records directly to the selected event group. Configure the event group in the Stations file, then sign in with an OpenSplitTime steward account. Credentials may be saved using the operating system's secure credential storage. If both staging and production event groups are configured, select the environment before signing in. Production sends times to the live event and requires confirmation when switching from staging.
 
-While signed in, OpenSplitTime status takes precedence over CSV export status in the timing-record indicator: yellow means pending upload, solid green means uploaded, and red means upload failed. Use **Pause Pushes** to temporarily stop automatic uploads without signing out; **Resume Pushes** restarts them. **Sign Out** returns the indicator to the CSV export state and does not change whether a record has been exported.
+While signed in, OpenSplitTime status takes precedence over CSV export status in the timing-record indicator. Use **Pause Pushes** to temporarily stop automatic uploads without signing out; **Resume Pushes** restarts them. **Sign Out** returns the indicator to the CSV export state and does not change whether a record has been exported.
+
+
+
 
 <span style="color:red">**Warning:** The functions marked in RED on the Settings page are completely destructive to the local database and **MUST NOT be performed during normal operation!** These are provided only for recovery of the database or data and should only be used at the direction of the software team.</span>
 
@@ -246,7 +257,7 @@ The following is a description of each button's function. Each of these will ope
 
 - **Load Stations File**
   This loads a `JSON` file containing each of the stations and their detailed information to allow ease of selection while setting up this application. A typical filename will be `eventname-YYYY-stations.json`.
-- **Load Athletes File**  
+- **Load Athletes File**
   This function loads a `.csv` file, supplied by race organizers, containing all athletes registered or checked in for the event, whether they are known to have started _or not_.
 - **Load DNS File**
   This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** the race.

--- a/src/renderer/src/assets/documents/get-started.md
+++ b/src/renderer/src/assets/documents/get-started.md
@@ -3,14 +3,17 @@
 # Ultra-Tracker Help
 
 ---
+
 ### Table of Contents
 
-
 ---
+
 ## Initial Setup
+
 <a id="markdown-initial-setup" name="initial-setup"></a>
 ![settings-page.png](./img/settings-page.png)
-1. Copy the event files into the event-configs folder:  
+
+1. Copy the event files into the event-configs folder:
    1. `\Documents\Ultra-Tracker\.event-config\`
 2. Load the Stations file
    1. Select Station location and set operator call sign
@@ -22,17 +25,21 @@
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
 ---
+
 <a id="markdown-sidebar" name="navigation-sidebar"></a>
 
 ## Navigation Sidebar
-The left side bar is used to select different pages.  Select from Stats, Roster, Logs, Export, Theme, Database, Settings and Help. Hovering over the sidebar area will expand it to show the names.
+
+The left side bar is used to select different pages. Select from Stats, Roster, Logs, Export, Theme, Database, Settings and Help. Hovering over the sidebar area will expand it to show the names.
 
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
 ---
+
 <a id="markdown-stats-page" name="stats-page"></a>
 
 ## Stats Page
+
 <div style="float: left">
    <img src="./img/bib.png">
 </div>
@@ -40,11 +47,11 @@ The BIB# entry field is the main starting point for using this page. This input 
 
 Clicking the In button and Out button will record the corresponding time entry.
 
-The datagrid columns can be Sorted by clicking on the column header.  Click again to toggle Ascending or Descending Sort. 
+The datagrid columns can be Sorted by clicking on the column header. Click again to toggle Ascending or Descending Sort.
 
 A Filter control for any column can be opened by clicking the Filter icon (three vertical dots).
 
-<span style="color:orange">**WARNING:** If the horizontal width of the Ultra-Tracker window is too small, the column filter buttons can overlap the column headers and cause the Sort and Filter features difficult to use.  The default layout has been carefully adjusted for modern HD resolutions but display scaling or screen resolution settings in the operating system can make the display too small to fit the default size of Ultra-Tracker.  Adjusting these settings will resolve this on most computers.</span>
+<span style="color:orange">**WARNING:** If the horizontal width of the Ultra-Tracker window is too small, the column filter buttons can overlap the column headers and cause the Sort and Filter features difficult to use. The default layout has been carefully adjusted for modern HD resolutions but display scaling or screen resolution settings in the operating system can make the display too small to fit the default size of Ultra-Tracker. Adjusting these settings will resolve this on most computers.</span>
 
 <a id="markdown-athlete-edit-function" name="editing-a-record"></a>
 <br clear="right"/>
@@ -54,18 +61,20 @@ A Filter control for any column can be opened by clicking the Filter icon (three
 </div>
 
 ### Editing a record
+
 To edit a timing record, click on the icon at the far-right side of the record row.
 
-The Edit pane allows modification or deletion of a timing record.  The In and Out times, DNF and DNS status, and any notes that have been entered will be displayed.  Changes to these fields must be applied to take effect, or cancelled to return to the Stats page.
+The Edit pane allows modification or deletion of a timing record. The In and Out times, DNF and DNS status, and any notes that have been entered will be displayed. Changes to these fields must be applied to take effect, or cancelled to return to the Stats page.
 
-If the Bib# can be matched with known athlete, the athlete's name will be displayed.  The button above the name will jump to that athlete in the Roster page.  A timing record for an unknown athlete is considered a warning condition, as all athletes should be known and checked in at the Start of the event, and included in the Athletes file. For a timing record not matched to athlete, limited changes can be performed, resolve the Bib# to a known athlete to modify all values.
+If the Bib# can be matched with known athlete, the athlete's name will be displayed. The button above the name will jump to that athlete in the Roster page. A timing record for an unknown athlete is considered a warning condition, as all athletes should be known and checked in at the Start of the event, and included in the Athletes file. For a timing record not matched to athlete, limited changes can be performed, resolve the Bib# to a known athlete to modify all values.
 
 <span style="color:red">**CAUTION:** Deleting a time record is permanent. An entry to the Log page is recorded for reference.</span>
 
 Validation Rules:
-* A record must have an In time.
-* An In time must occur before the Out time.
-* Commas are not allowed in the Note field, and will be replaced with semi-colons.
+
+- A record must have an In time.
+- An In time must occur before the Out time.
+- Commas are not allowed in the Note field, and will be replaced with semi-colons.
 
 <br clear="right"/>
 
@@ -85,42 +94,48 @@ Each of the different statistics available are updated in real-time.
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
 ---
+
 <a id="markdown-keyboard-shortcuts" name="keyboard-shortcuts"></a>
 
 ### Keyboard shortcuts
+
 Entry of numbers and times is assisted by using some specific keys on both an 88 key (or more) keyboard or a 10-key Numpad. When the cursor is focused in the **Bib#** box, entering a bib number and pressing one of these keys will automatically enter the record and populate the corresponding time.
 
-*10-key entry is recommended for all stations, for laptops without, use a USB 10-key peripheral.*
+_10-key entry is recommended for all stations, for laptops without, use a USB 10-key peripheral._
 
 > | <div style="width:150px;fontSize:larger">**In**</div> | <div style="width:150px;fontSize:larger">**Out**</div> | <div style="width:150px;fontSize:larger">**In and Out**</div> |
-> | :------------- | :---------------- | :-------------- |
-> | [Equal]        | [Minus]           | [Slash]         |
-> | [Enter]        | [Numpad-Subtract] | [Backslash]     |
-> | [Numpad-Add]   |                   | [Numpad-Divide] |
-> | [Numpad-Enter] |                   |                 |
+> | :---------------------------------------------------- | :----------------------------------------------------- | :------------------------------------------------------------ |
+> | [Equal]                                               | [Minus]                                                | [Slash]                                                       |
+> | [Enter]                                               | [Numpad-Subtract]                                      | [Backslash]                                                   |
+> | [Numpad-Add]                                          |                                                        | [Numpad-Divide]                                               |
+> | [Numpad-Enter]                                        |                                                        |                                                               |
 
 ![keyboard-layout.png](./img/keyboard-layout.png)
 
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
 ---
+
 <a id="markdown-roster-page" name="roster-page"></a>
 
 ## Roster Page
+
 <div style="float:left;margin:0 10px 10px 0" markdown="1">
 
 ![roster-page.png](./img/roster-page.png)
 </div>
 This page provides the list of all athletes and enable the operator to search for an athlete using different search keys, such as, name, bib number, city, start time, Station TimeIn, Station TimeOut and note entries.
 
-The Status column helps station operators determine which athletes are pertinent to the station.  Valid filter options for the Status column are: `Incoming, DNS, In, Out, Medical, Timeout, Withdrew`
+The Status column helps station operators determine which athletes are pertinent to the station. Valid filter options for the Status column are: `Incoming, DNS, In, Out, Medical, Timeout, Withdrew`
 
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
 ---
+
 <a id="markdown-stations-page" name="stations-page"></a>
 
 ## Stations Page
+
 <div style="float:left;margin:0 10px 10px 0" markdown="1">
 
 ![stations.png](./img/stations.png)
@@ -132,9 +147,11 @@ This page also shows the details about the aid stations throughout the race, loc
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
 ---
+
 <a id="markdown-logs-page" name="logs-page"></a>
 
 ## Logs Page
+
 <div style="float:left;margin:0 10px 10px 0" markdown="1">
 
 ![logs-page.png](./img/logs-page.png)
@@ -147,9 +164,11 @@ This page displays the station log file that is auto-generated during station op
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
 ---
+
 <a id="markdown-export-page" name="export-page"></a>
 
 ## Export Page
+
 <div style="float:left;margin:0 10px 10px 0" markdown="1">
 
 ![export-page.png](./img/export-page.png)
@@ -157,32 +176,36 @@ This page displays the station log file that is auto-generated during station op
 This page provides Export utilities for sending station data to another station or race organizers.  These file formats are optimized for human and machine readability.
 <br/><br/>
 
-- **Export Incremental CSV File**
-This function exports a `.csv` file of the station entries containing unsent or edited records, contains BibID, TimeIn, TimeOut, DNF/DNS status and any notes made by the operator.  The exported file will be automatically named and  incremented. e.g. `Aid05Times_04i.csv, Aid05Times_05i.csv, and Aid05Times_06i.csv`.
+When OpenSplitTime is not signed in, the indicator at the left of each timing record shows its CSV export state: a gray hollow circle means the record has not been exported, and a green hollow circle means it has been exported. A successful incremental or full CSV export marks its included records as exported.
 
-  Sending recent time records in smaller batches allows for much smaller files being routinely sent to race leadership to import to the race timing site, whether by packet radio or internet. This keeps timing data updated timely for athlete support crews and other situation in an event.  Depending on the rate of athletes arriving and departing a station, sending an incremental file _every 30 minutes at a minimim_ is recommended, more often if possible.
-  
-  A station setup with a data entry PC networked to a data transmission PC is recommended so interruption of data entry is limited to a quick Incremental Export operation.  This allows the data transmission operator to access the exported files independently.
+- **Export Incremental CSV File**
+  This function exports a `.csv` file of the station entries containing unsent or edited records, contains BibID, TimeIn, TimeOut, DNF/DNS status and any notes made by the operator. The exported file will be automatically named and incremented. e.g. `Aid05Times_04i.csv, Aid05Times_05i.csv, and Aid05Times_06i.csv`.
+
+  Sending recent time records in smaller batches allows for much smaller files being routinely sent to race leadership to import to the race timing site, whether by packet radio or internet. This keeps timing data updated timely for athlete support crews and other situation in an event. Depending on the rate of athletes arriving and departing a station, sending an incremental file _every 30 minutes at a minimim_ is recommended, more often if possible.
+
+  A station setup with a data entry PC networked to a data transmission PC is recommended so interruption of data entry is limited to a quick Incremental Export operation. This allows the data transmission operator to access the exported files independently.
 
   <span style="color:orange">**NOTE:** All Incremental files must be transmitted to the race leadership as each file only contains a portion of the overall station data.</span>
 
 - **Export Full CSV File**
-This function exports a full `.csv` file of **all time records** containing TimeIn, TimeOut, DNF/DNS status and any notes made by the station operators.
+  This function exports a full `.csv` file of **all time records** containing TimeIn, TimeOut, DNF/DNS status and any notes made by the station operators.
 
 This file is useful as a final station report.
 
 - **Export DNS File**
-This function exports a `.csv` file with all DNS entries that have occurred at the current station.  This is unlikely to be used at any station other than the Start Line.
+  This function exports a `.csv` file with all DNS entries that have occurred at the current station. This is unlikely to be used at any station other than the Start Line.
 
 - **Export DNF File**
-This function exports a `.csv` file with all DNF entries that have occurred up the current station.  This file is not normally needed to be sent to race organizers but can be an efficient way of sending the current station's DNF list to another station.
+  This function exports a `.csv` file with all DNF entries that have occurred up the current station. This file is not normally needed to be sent to race organizers but can be an efficient way of sending the current station's DNF list to another station.
 
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
 ---
+
 <a id="markdown-theme-page" name="theme-page"></a>
 
 ## Theme Page
+
 <div style="float:left;margin:0 10px 10px 0" markdown="1">
 
 ![theme-page.png](./img/theme-page.png)
@@ -192,63 +215,77 @@ This is a global selection that allows two different color/shading options for u
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
 ---
+
 <a id="markdown-settings-page" name="settings-page"></a>
 
 ## Settings Page
+
 <div style="float:left;margin:0 10px 10px 0" markdown="1">
 
 ![settings-page.png](./img/settings-page.png)
 </div>
 The purpose of this page is to allow the operator to import the various input files and manage the database needed for proper program operation. By default, system initialization files should be copied into user documents directory and file reading/writing selection dialogs will open here.
 
-   * **Windows:** `%userprofile%\Documents\ultra-tracker\`
-   * **Linux:** `$HOME/Documents/ultra-tracker`
-   * **MacOS:**  `/Users/username/Documents/ultra-tracker`
+- **Windows:** `%userprofile%\Documents\ultra-tracker\`
+- **Linux:** `$HOME/Documents/ultra-tracker`
+- **MacOS:** `/Users/username/Documents/ultra-tracker`
 
-<span style="color:red">**Warning:** The functions marked in RED on the Settings page are completely destructive to the local database and **MUST NOT be performed during normal operation!**  These are provided only for recovery of the database or data and should only be used at the direction of the software team.</span>
+### OpenSplitTime
+
+OpenSplitTime is an optional integration for sending timing records directly to the selected event group. Configure the event group in the Stations file, then sign in with an OpenSplitTime steward account. Credentials may be saved using the operating system's secure credential storage. If both staging and production event groups are configured, select the environment before signing in. Production sends times to the live event and requires confirmation when switching from staging.
+
+While signed in, OpenSplitTime status takes precedence over CSV export status in the timing-record indicator: yellow means pending upload, solid green means uploaded, and red means upload failed. Use **Pause Pushes** to temporarily stop automatic uploads without signing out; **Resume Pushes** restarts them. **Sign Out** returns the indicator to the CSV export state and does not change whether a record has been exported.
+
+<span style="color:red">**Warning:** The functions marked in RED on the Settings page are completely destructive to the local database and **MUST NOT be performed during normal operation!** These are provided only for recovery of the database or data and should only be used at the direction of the software team.</span>
 
 <span style="color:orange">**NOTE:** The functions in ORANGE are provided as a means to completely recover after a major database error and other methods have not corrected the issue.</span>
 
-The following is a description of each button's function.  Each of these will open a file open dialog to the `\Documents\Ultra-Tracker\.event-config\` directory.
+The following is a description of each button's function. Each of these will open a file open dialog to the `\Documents\Ultra-Tracker\.event-config\` directory.
 
 #### Station Setup
-* **Load Stations File**
-This loads a `JSON` file containing each of the stations and their detailed information to allow ease of selection while setting up this application. A typical filename will be `eventname-YYYY-stations.json`.
-* **Load Athletes File**  
-This function loads a `.csv` file, supplied by race organizers, containing all athletes registered or checked in for the event, whether they are known to have started _or not_.
-* **Load DNS File**
-This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** the race.
-* **Load DNF File**
-This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not finished** the race.
+
+- **Load Stations File**
+  This loads a `JSON` file containing each of the stations and their detailed information to allow ease of selection while setting up this application. A typical filename will be `eventname-YYYY-stations.json`.
+- **Load Athletes File**  
+  This function loads a `.csv` file, supplied by race organizers, containing all athletes registered or checked in for the event, whether they are known to have started _or not_.
+- **Load DNS File**
+  This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** the race.
+- **Load DNF File**
+  This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not finished** the race.
 
   As an event proceeds more DNF athletes will be recorded and new DNF files will be supplied to stations.
 
-  Importing new DNF files will update all athletes recorded and DNF earlier in the race, DNFs past the current station are ignored.  This provides insight of which athletes are still expected into the current station.
+  Importing new DNF files will update all athletes recorded and DNF earlier in the race, DNFs past the current station are ignored. This provides insight of which athletes are still expected into the current station.
 
 #### RFID Configuration
-* **Initialize RFID**
-Starts and stops a RFID reader service for the Zebra FXR90 hardware.  These controls are enabled only for Start and Finish Line stations only.  Integrations with more RFID hardware will be possible in the future.
+
+- **Initialize RFID**
+  Starts and stops a RFID reader service for the Zebra FXR90 hardware. These controls are enabled only for Start and Finish Line stations only. Integrations with more RFID hardware will be possible in the future.
 
 #### Application Settings
-* **Reset App Settings** 
-This will reset the local application settings file to defaults.  This can be useful for recovering from an unexpected error.
-The application settings file `config.json` is located at:
 
- * **Windows:** `%appdata%\ultra-tracker`
- * **Linux:** `~/.config/ultra-tracker`
- * **MacOS:**  `~/Library/Application Support/ultra-tracker`
+- **Reset App Settings**
+  This will reset the local application settings file to defaults. This can be useful for recovering from an unexpected error.
+  The application settings file `config.json` is located at:
+
+- **Windows:** `%appdata%\ultra-tracker`
+- **Linux:** `~/.config/ultra-tracker`
+- **MacOS:** `~/Library/Application Support/ultra-tracker`
 
 #### Developer Tools
-* **Recreate Database**
-This function is the means where *ALL* **database entries and tables are removed** resulting in the loss of *ALL* setup data and entry history!  The intent is to allow recovery of a major database corruption event and the rapid rebuild and subsequent return to normal operation by the operator.
-* **Recover Data From CSV File**
-This function imports **ALL of the entries** that have previously been made by the operator since the start of this race event!  The Ultra-Tracker application has been automatically producing a file containing EVERY entry made by the operator continuously during normal operation! This function will restore all of this data to restore the program to the previous state automatically.
+
+- **Recreate Database**
+  This function is the means where _ALL_ **database entries and tables are removed** resulting in the loss of _ALL_ setup data and entry history! The intent is to allow recovery of a major database corruption event and the rapid rebuild and subsequent return to normal operation by the operator.
+- **Recover Data From CSV File**
+  This function imports **ALL of the entries** that have previously been made by the operator since the start of this race event! The Ultra-Tracker application has been automatically producing a file containing EVERY entry made by the operator continuously during normal operation! This function will restore all of this data to restore the program to the previous state automatically.
 
 <a id="markdown-recovery-procedure" name="station-recovery-procedure"></a>
 
 ### Station Recovery Procedure
+
 **If instructed to do so,**
 <span style="color:orange">after **Recreate Database** has been performed, perform the following steps:</span>
+
 1. Load the Stations file.
 1. Load the Athletes file.
 1. Load the DNS file.
@@ -256,14 +293,17 @@ This function imports **ALL of the entries** that have previously been made by t
 1. Import a Full Export file using "Recover Data From CSV File".
 
 ### Local Database
-Ultra-Tracker runs a modern database on the local machine.  All transactions are preserved immediately and the operator can close and re-open the app without loss of data.  A background task backs up the database to a secondary file, every 5 minutes.  This backup is used for emergency use only and may not restore all data in a data-loss event.  *Do not modify the local database files using external tools!*
+
+Ultra-Tracker runs a modern database on the local machine. All transactions are preserved immediately and the operator can close and re-open the app without loss of data. A background task backs up the database to a secondary file, every 5 minutes. This backup is used for emergency use only and may not restore all data in a data-loss event. _Do not modify the local database files using external tools!_
 
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
 ---
+
 <a id="markdown-about-ultra-tracker" name="about-ultra-tracker"></a>
 
 ## About Ultra-Tracker
+
 A cross-platform desktop application for tracking athletes during ultra marathons.
 This project is supported on Windows, Linux, and MacOS.
 
@@ -276,19 +316,21 @@ Built as an Electron application using TypeScript + React + Tailwind CSS.
 <a id="markdown-contributors" name="contributors"></a>
 
 ## Contributors
+
 > | <div style="width:200px;fontSize:larger">**Name**</div> | <div style="width:100px;fontSize:larger">**Call Sign**</div> | <div style="width:200px;> fontSize:larger">**GitHub**</div> |
-> | :------------------- | :----------- | :----------------------------------------------------- |
-> | **Jaren Glenn**      | ---          | [**@derethil**](https://github.com/derethil)           |
-> | **David Leikis**     | KG7EW        | [**@DLeikis**](https://github.com/DLeikis)             |
-> | **Russ Leikis**      | KE7VFI       | [**@rleikis**](https://github.com/rleikis)             |
-> | **Jorden Luke**      | KF7YEM       | [**@JordenLuke**](https://github.com/JordenLuke)       |
-> | **Brian Marble**     | KG7AFQ       | [**@brianmarble**](https://github.com/brianmarble)     |
-> | **Mitch Smith**      | N8MLS        | [**@pxls2prnt**](https://github.com/pxls2prnt)         |
-> | **Brandon Tibbitts** | KD7IIW       | [**@Tibbs327**](https://github.com/Tibbs327)           |
+> | :------------------------------------------------------ | :----------------------------------------------------------- | :---------------------------------------------------------- |
+> | **Jaren Glenn**                                         | ---                                                          | [**@derethil**](https://github.com/derethil)                |
+> | **David Leikis**                                        | KG7EW                                                        | [**@DLeikis**](https://github.com/DLeikis)                  |
+> | **Russ Leikis**                                         | KE7VFI                                                       | [**@rleikis**](https://github.com/rleikis)                  |
+> | **Jorden Luke**                                         | KF7YEM                                                       | [**@JordenLuke**](https://github.com/JordenLuke)            |
+> | **Brian Marble**                                        | KG7AFQ                                                       | [**@brianmarble**](https://github.com/brianmarble)          |
+> | **Mitch Smith**                                         | N8MLS                                                        | [**@pxls2prnt**](https://github.com/pxls2prnt)              |
+> | **Brandon Tibbitts**                                    | KD7IIW                                                       | [**@Tibbs327**](https://github.com/Tibbs327)                |
 
 <a id="markdown-license" name="license"></a>
 
 ## License
+
 [MIT](https://opensource.org/license/mit) ©2025 [Bridgerland Amateur Radio Club](https://barconline.org/)
 
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>

--- a/src/renderer/src/features/DataGrid/TableContent.tsx
+++ b/src/renderer/src/features/DataGrid/TableContent.tsx
@@ -24,7 +24,17 @@ export function TableContent<T extends object>(props: Props<T>) {
   const statusClass = (status: RowStatus) => {
     if (status === "success") return "bg-success";
     if (status === "error") return "bg-danger";
-    return "bg-[#FBBE00]";
+    if (status === "pending") return "bg-[#FBBE00]";
+    if (status === "exported") return "border-2 border-success";
+    return "border-2 border-gray-500";
+  };
+
+  const statusLabel = (status: RowStatus) => {
+    if (status === "success") return "Uploaded";
+    if (status === "error") return "Upload failed";
+    if (status === "pending") return "Pending upload";
+    if (status === "exported") return "Exported";
+    return "Not exported";
   };
 
   const renderCell = (column: Column<T>, row: T) => {
@@ -49,17 +59,20 @@ export function TableContent<T extends object>(props: Props<T>) {
           last={isLast(row.index)}
           ref={props.rowVirtualizer.measureElement}
         >
-          {props.rowStatus && (
-            <td
-              className="w-4 px-1"
-              aria-label={`OpenSplitTime upload status: ${props.rowStatus(props.data[row.index])}`}
-            >
-              <span
-                className={`block h-3 w-3 rounded-full ${statusClass(props.rowStatus(props.data[row.index]))}`}
-                aria-hidden="true"
-              />
-            </td>
-          )}
+          {props.rowStatus &&
+            (() => {
+              const status = props.rowStatus(props.data[row.index]);
+              const label = statusLabel(status);
+
+              return (
+                <td className="w-4 px-1" aria-label={label} title={label}>
+                  <span
+                    className={`block h-3 w-3 rounded-full ${statusClass(status)}`}
+                    aria-hidden="true"
+                  />
+                </td>
+              );
+            })()}
           {props.columns.map((column) => (
             <Cell
               key={column.name ?? String(column.field)}

--- a/src/renderer/src/features/DataGrid/types.ts
+++ b/src/renderer/src/features/DataGrid/types.ts
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 
-export type RowStatus = "success" | "pending" | "error";
+export type RowStatus = "success" | "pending" | "error" | "exported" | "not-exported";
 
 export type Column<T extends object> = {
   [K in keyof T]: {

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -1,12 +1,19 @@
 import { Stack } from "~/components";
 import { StatusTag } from "~/components/StatusTag";
 import { ColumnDef, DataGrid } from "~/features/DataGrid";
+import { RowStatus } from "~/features/DataGrid/types";
 import { formatDate } from "~/lib/datetimes";
 import { DNFType, RecordStatus } from "$shared/enums";
 import { EditRunner } from "./EditRunner";
 import { InTimeCell } from "./InTimeCell";
 import { RunnerFormStats } from "./RunnerFormStats";
 import { RunnerEx, useRunnerData } from "../../hooks/data/useRunnerData";
+
+function getRowStatus(row: RunnerEx): RowStatus {
+  if (!row.openSplitTimeAuthenticated) return row.sent ? "exported" : "not-exported";
+
+  return row.openSplitTimePushStatus ?? "pending";
+}
 
 export function RunnerEntry() {
   const { data: runnerData } = useRunnerData();
@@ -67,7 +74,7 @@ export function RunnerEntry() {
             field: "sequence",
             ascending: false
           }}
-          rowStatus={(row) => row.openSplitTimePushStatus ?? (row.sent ? "success" : "pending")}
+          rowStatus={getRowStatus}
         />
       </div>
     </Stack>

--- a/src/renderer/src/features/SettingsPage/OpenSplitTimeLogin.tsx
+++ b/src/renderer/src/features/SettingsPage/OpenSplitTimeLogin.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Button, Modal, Select, Stack, TextInput, VerticalButtonGroup } from "~/components";
 import { useIpcRenderer } from "~/hooks/useIpcRenderer";
 
@@ -35,6 +36,7 @@ interface OpenSplitTimeLoginProps {
 
 export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) {
   const ipcRenderer = useIpcRenderer();
+  const queryClient = useQueryClient();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [expiration, setExpiration] = useState<string | null>(null);
@@ -115,13 +117,14 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
           if (!authStatus.authenticated) {
             setSessionExpired(true);
             setExpiration(null);
+            queryClient.invalidateQueries({ queryKey: ["runners-table"] });
           }
         })
         .catch(() => undefined);
     }, 20_000);
 
     return () => clearInterval(interval);
-  }, [ipcRenderer, expiration]);
+  }, [ipcRenderer, expiration, queryClient]);
 
   const applyEnvironment = async (nextEnvironment: OpenSplitTimeEnvironment) => {
     await ipcRenderer.invoke("opensplittime-set-environment", { environment: nextEnvironment });
@@ -163,6 +166,7 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
       setPushPaused(false);
       setSessionExpired(false);
       setPassword("");
+      await queryClient.invalidateQueries({ queryKey: ["runners-table"] });
     } catch {
       setExpiration(null);
       setError(true);
@@ -183,6 +187,7 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
       setExpiration(result.expiration);
       setPushPaused(false);
       setSessionExpired(false);
+      await queryClient.invalidateQueries({ queryKey: ["runners-table"] });
     } catch {
       setExpiration(null);
       setError(true);
@@ -197,6 +202,7 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
     setPassword("");
     setPushPaused(true);
     setSessionExpired(false);
+    await queryClient.invalidateQueries({ queryKey: ["runners-table"] });
   };
 
   const handleTogglePush = async () => {

--- a/src/renderer/src/hooks/data/useRunnerData.tsx
+++ b/src/renderer/src/hooks/data/useRunnerData.tsx
@@ -17,6 +17,7 @@ export interface Runner {
 export interface RunnerEx extends Runner {
   sequence: number;
   sent: boolean;
+  openSplitTimeAuthenticated: boolean;
   dns: boolean;
   dnf: boolean;
   dnfType: DNFType;
@@ -48,8 +49,12 @@ export function useRunnerData() {
   return useQuery({
     queryKey: ["runners-table"],
     queryFn: async (): Promise<RunnerEx[]> => {
-      const response = await ipcRenderer.invoke("get-runners-table", { includeDNF: true });
+      const [response, authResult] = await Promise.all([
+        ipcRenderer.invoke("get-runners-table", { includeDNF: true }),
+        ipcRenderer.invoke("opensplittime-get-auth-status")
+      ]);
       const [data, status, message]: DatabaseResponse<RunnerAthleteDB[]> = response;
+      const { authenticated } = authResult as { authenticated: boolean };
 
       const success = handleError(status, message);
 
@@ -63,6 +68,7 @@ export function useRunnerData() {
         out: runner.timeOut,
         note: runner.note,
         sent: runner.sent,
+        openSplitTimeAuthenticated: authenticated,
         dns: runner.dns ?? false,
         dnf: runner.dnf ?? false,
         dnfType: runner.dnfType ?? DNFType.None,


### PR DESCRIPTION
## Summary
Adds CSV-versus-OpenSplitTime timing-record status indicators, marks records included in full CSV exports as exported, and keeps successful OpenSplitTime pushes from setting the CSV export state. Updates the main README and bundled Help documentation with the operator-facing status behavior.

| Integration state | Indicator | Meaning |
| :--- | :--- | :--- |
| Not signed in | <img src="https://raw.githubusercontent.com/barcradio/ultra-tracker/develop/src/renderer/public/img/status/not-exported.svg" alt="Gray hollow circle" width="16"> | The record has not been exported to CSV. |
| Not signed in | <img src="https://raw.githubusercontent.com/barcradio/ultra-tracker/develop/src/renderer/public/img/status/exported.svg" alt="Green hollow circle" width="16"> | The record was included in a successful incremental or full CSV export. |
| Signed in | <img src="https://raw.githubusercontent.com/barcradio/ultra-tracker/develop/src/renderer/public/img/status/upload-pending.svg" alt="Yellow solid circle" width="16"> | The record is pending OpenSplitTime upload. |
| Signed in | <img src="https://raw.githubusercontent.com/barcradio/ultra-tracker/develop/src/renderer/public/img/status/uploaded.svg" alt="Green solid circle" width="16"> | The record was uploaded to OpenSplitTime. |
| Signed in | <img src="https://raw.githubusercontent.com/barcradio/ultra-tracker/develop/src/renderer/public/img/status/upload-failed.svg" alt="Red solid circle" width="16"> | The OpenSplitTime upload failed. |

## Changes
- **Status indicators**: Show CSV export state when signed out and OpenSplitTime upload state when signed in.
- **CSV exports**: Mark records included in full exports as exported after a successful write.
- **OpenSplitTime**: Preserve CSV export state when an upload succeeds.
- **Documentation**: Document the indicators and export behavior in README and bundled Help.

## Testing
- Not run: Git PR workflow does not run linters, typechecks, builds, or tests.