### PR TITLE
fix(build): lower node-abi compatibility baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "husky": "^9.1.7",
     "is-core-module": "^2.16.2",
-    "node-abi": "^3.95.0",
+    "node-abi": "^3.94.0",
     "postcss": "^8.5.26",
     "prettier": "^3.9.6",
     "react": "^19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,7 +257,7 @@ importers:
         specifier: ^2.16.2
         version: 2.16.2
       node-abi:
-        specifier: ^3.95.0
+        specifier: ^3.94.0
         version: 3.95.0
       postcss:
         specifier: ^8.5.26


### PR DESCRIPTION
## Summary
Lowers the declared `node-abi` compatibility baseline from `^3.95.0` to `^3.94.0` while retaining the existing `3.95.0` lock resolution. This preserves compatibility with the earlier 3.94 release for Electron packaging tooling without changing the currently installed dependency.

## Changes
- **Build tooling**: update the direct `node-abi` semver range in the package manifest and matching lockfile importer metadata.
- **Resolution behavior**: retain the `3.95.0` lockfile resolution because it satisfies the broadened `^3.94.0` range.

## Testing
- Not run: PR workflow only; no implementation validation was performed.
- Git/history review: `node-abi@3.95.0` is consumed transitively by Electron rebuild/packaging tooling, and repository history does not record a defect in `3.95.0`.