### PR TITLE
fix(renderer): prevent toast provider startup crash

### DIFF
--- a/src/renderer/src/features/Toasts/ToastsProvider.tsx
+++ b/src/renderer/src/features/Toasts/ToastsProvider.tsx
@@ -21,7 +21,7 @@ function useMainToastListener(createToast: (toast: Toast) => void) {
     ipcRenderer.on("create-toast", listener);
 
     return () => {
-      ipcRenderer.off("create-toast", listener);
+      ipcRenderer.removeListener("create-toast", listener);
     };
   }, [createToast, ipcRenderer]);
 }


### PR DESCRIPTION
## Summary
- Replace the unsupported `ipcRenderer.off` cleanup call with `removeListener` in `ToastProvider`.
- Prevent the renderer crash that left the Electron GUI unavailable after startup.

## Validation
- `pnpm run typecheck:web`
- `pnpm dev` reaches `Main window ready to show` without the `ipcRenderer.off is not a function` error.