### PR TITLE
fix: block pushes when no OST metadata is available

### DIFF
--- a/resources/config/stations-template.json
+++ b/resources/config/stations-template.json
@@ -4,7 +4,23 @@
         "starttime": "00:00:00 Jan 01 2024",
         "endtime": "00:00:00 Jan 01 2024",
         "startline": "0-start-line",
-        "finishline": "99-finish-line"
+        "finishline": "99-finish-line",
+        "openSplitTime": {
+            "production": {
+                "name": "event-name-prod",
+                "id": 9999
+            },
+            "staging": {
+                "name": "event-name-staging",
+                "id": 9999
+            },
+            "splitNames": {
+                "0-start-line": "Start",
+                "1-station-name": "Station Name",
+                "2-station-name": "Station Name",
+                "3-finish-line": "Finish"
+            }
+        }
     },
     "stations": [
         {

--- a/src/main/database/stations-db.ts
+++ b/src/main/database/stations-db.ts
@@ -61,8 +61,7 @@ export async function LoadStations() {
   // TODO: Begin transaction
   for (const index in stationData) {
     if (index == "event") {
-      const stagingEvent = stationData.event.openSplitTime?.staging;
-      appStore.set("event.name", stagingEvent?.name || stationData.event.name);
+      appStore.set("event.name", stationData.event.name);
       appStore.set("event.starttime", formatDate(stationData.event.starttime));
       appStore.set("event.endtime", formatDate(stationData.event.endtime));
       appStore.set(

--- a/src/main/ipc/opensplittime-ipc.ts
+++ b/src/main/ipc/opensplittime-ipc.ts
@@ -15,6 +15,7 @@ import {
   getEventGroup,
   getOpenSplitTimeEnvironment,
   getSavedCredentials,
+  isOpenSplitTimeEventGroupConfigured,
   isOpenSplitTimePushPaused,
   listOpenSplitTimeEnvironments,
   pushTimeRecordUpdate,
@@ -96,6 +97,10 @@ const getOpenSplitTimeEventGroup: Handler<EventGroupParams> = (_, params) => {
 
 const getOpenSplitTimePushPaused: Handler = () => ({ paused: isOpenSplitTimePushPaused() });
 
+const getOpenSplitTimeEventGroupConfigured: Handler = () => ({
+  configured: isOpenSplitTimeEventGroupConfigured()
+});
+
 const setOpenSplitTimePushPausedHandler: Handler<SetPushPausedParams> = (_, params) => {
   if (typeof params?.paused !== "boolean") {
     throw new TypeError("paused must be a boolean");
@@ -146,6 +151,7 @@ export const initOpenSplitTimeHandlers = () => {
   ipcMain.handle("opensplittime-submit-raw-times", submitOpenSplitTimeRawTimes);
   ipcMain.handle("opensplittime-clear-authentication", clearAuthentication);
   ipcMain.handle("opensplittime-get-push-paused", getOpenSplitTimePushPaused);
+  ipcMain.handle("opensplittime-get-event-group-configured", getOpenSplitTimeEventGroupConfigured);
   ipcMain.handle("opensplittime-set-push-paused", setOpenSplitTimePushPausedHandler);
   ipcMain.handle("opensplittime-push-record", pushOpenSplitTimeRecord);
 

--- a/src/main/services/opensplittime.ts
+++ b/src/main/services/opensplittime.ts
@@ -128,8 +128,27 @@ export function isOpenSplitTimePushPaused(): boolean {
   return pushPaused;
 }
 
+// The stations file must supply an OST event group for the active environment before pushes
+// may run; otherwise every push would fail against a nonexistent or wrong event group.
+export function isOpenSplitTimeEventGroupConfigured(): boolean {
+  const eventMetadata = appStore.get("event.openSplitTime") as
+    OpenSplitTimeEventMetadataStore | undefined;
+  const configuredEvent =
+    currentEnvironment === "production" ? eventMetadata?.production : eventMetadata?.staging;
+
+  return Boolean(configuredEvent?.name);
+}
+
 export function setOpenSplitTimePushPaused(paused: boolean): void {
   requireToken();
+
+  if (!paused && !isOpenSplitTimeEventGroupConfigured()) {
+    throw new OpenSplitTimeApiError(
+      `OpenSplitTime event group is not configured for the ${currentEnvironment} environment`,
+      500
+    );
+  }
+
   pushPaused = paused;
 }
 
@@ -312,6 +331,7 @@ export async function authenticate(
   saveCredentials = false
 ): Promise<OpenSplitTimeAuthResult> {
   apiToken = null;
+
   const response = await request<OpenSplitTimeAuthResponse>("/auth", {
     method: "POST",
     headers: {
@@ -332,7 +352,8 @@ export async function authenticate(
 
   apiToken = response.token;
   tokenExpiration = response.expiration;
-  pushPaused = false;
+  // Sign-in is always allowed, but pushes stay paused until an event group is configured.
+  pushPaused = !isOpenSplitTimeEventGroupConfigured();
 
   if (saveCredentials && safeStorage.isEncryptionAvailable()) {
     appStore.set("openSplitTime.email", email);
@@ -359,7 +380,7 @@ export async function syncEventGroupId(): Promise<void> {
     OpenSplitTimeEventMetadataStore | undefined;
   const configuredEvent =
     currentEnvironment === "production" ? eventMetadata?.production : eventMetadata?.staging;
-  const eventGroupIdOrSlug = configuredEvent?.name || (appStore.get("event.name") as string);
+  const eventGroupIdOrSlug = configuredEvent?.name;
 
   if (!eventGroupIdOrSlug) return;
 
@@ -453,14 +474,20 @@ function resolvePushConfig(): OpenSplitTimePushConfig {
     OpenSplitTimeEventMetadataStore | undefined;
   const configuredEvent =
     currentEnvironment === "production" ? eventMetadata?.production : eventMetadata?.staging;
-  const eventGroupIdOrSlug = configuredEvent?.name || (appStore.get("event.name") as string);
+  const eventGroupIdOrSlug = configuredEvent?.name;
   const stationIdentifier = appStore.get("station.identifier") as string;
   const stationName = appStore.get("station.name") as string;
   // The OST split name must match a split already configured on the event group; use the
   // stations-file override when the station name itself doesn't line up with OST's naming.
   const splitName = (appStore.get("station.openSplitTimeSplitName") as string) || stationName;
 
-  if (!eventGroupIdOrSlug || !stationIdentifier || !stationName) {
+  if (!eventGroupIdOrSlug) {
+    throw new OpenSplitTimeApiError(
+      `OpenSplitTime event group is not configured for the ${currentEnvironment} environment; reload the stations file`,
+      500
+    );
+  }
+  if (!stationIdentifier || !stationName) {
     throw new OpenSplitTimeApiError("OpenSplitTime event or station is not configured", 500);
   }
 

--- a/src/renderer/src/features/SettingsPage/OpenSplitTimeLogin.tsx
+++ b/src/renderer/src/features/SettingsPage/OpenSplitTimeLogin.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button, Modal, Select, Stack, TextInput, VerticalButtonGroup } from "~/components";
 import { useIpcRenderer } from "~/hooks/useIpcRenderer";
 
@@ -40,7 +40,7 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [expiration, setExpiration] = useState<string | null>(null);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [saveCredentials, setSaveCredentials] = useState(false);
   const [hasSavedCredentials, setHasSavedCredentials] = useState(false);
@@ -53,6 +53,17 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
   );
   const [pushPaused, setPushPaused] = useState(true);
   const [sessionExpired, setSessionExpired] = useState(false);
+
+  // Refetches on mount/remount and whenever the environment changes, and is invalidated
+  // whenever a stations file is (re)loaded so a missing OST event group is caught immediately.
+  const { data: eventGroupConfiguredResult } = useQuery({
+    queryKey: ["opensplittime-event-group-configured", environment],
+    queryFn: () =>
+      ipcRenderer.invoke("opensplittime-get-event-group-configured") as Promise<{
+        configured: boolean;
+      }>
+  });
+  const eventGroupConfigured = eventGroupConfiguredResult?.configured ?? true;
 
   useEffect(() => {
     let isMounted = true;
@@ -152,7 +163,7 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setError(false);
+    setError(null);
     setIsSubmitting(true);
 
     try {
@@ -163,13 +174,16 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
       })) as OpenSplitTimeAuthResult;
       setExpiration(result.expiration);
       setHasSavedCredentials(result.credentialsSaved);
-      setPushPaused(false);
+      const pushStatus = (await ipcRenderer.invoke("opensplittime-get-push-paused")) as {
+        paused: boolean;
+      };
+      setPushPaused(pushStatus.paused);
       setSessionExpired(false);
       setPassword("");
       await queryClient.invalidateQueries({ queryKey: ["runners-table"] });
-    } catch {
+    } catch (error) {
       setExpiration(null);
-      setError(true);
+      setError(error instanceof Error ? error.message : "Sign-in failed.");
     } finally {
       setPassword("");
       setIsSubmitting(false);
@@ -177,7 +191,7 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
   };
 
   const handleSavedLogin = async () => {
-    setError(false);
+    setError(null);
     setIsSubmitting(true);
 
     try {
@@ -185,12 +199,15 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
         "opensplittime-authenticate-saved"
       )) as OpenSplitTimeAuthResult;
       setExpiration(result.expiration);
-      setPushPaused(false);
+      const pushStatus = (await ipcRenderer.invoke("opensplittime-get-push-paused")) as {
+        paused: boolean;
+      };
+      setPushPaused(pushStatus.paused);
       setSessionExpired(false);
       await queryClient.invalidateQueries({ queryKey: ["runners-table"] });
-    } catch {
+    } catch (error) {
       setExpiration(null);
-      setError(true);
+      setError(error instanceof Error ? error.message : "Sign-in failed.");
     } finally {
       setIsSubmitting(false);
     }
@@ -209,8 +226,13 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
     if (!expiration) return;
 
     const nextPaused = !pushPaused;
-    await ipcRenderer.invoke("opensplittime-set-push-paused", { paused: nextPaused });
-    setPushPaused(nextPaused);
+    setError(null);
+    try {
+      await ipcRenderer.invoke("opensplittime-set-push-paused", { paused: nextPaused });
+      setPushPaused(nextPaused);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : "Unable to change push state.");
+    }
   };
 
   return (
@@ -238,7 +260,15 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
           <span className="text-sm font-medium text-on-component">
             Pushes to OpenSplitTime are {pushPaused ? "paused" : "active"}.
           </span>
-          <Button type="button" size="wide" onClick={handleTogglePush} disabled={!expiration}>
+          {!eventGroupConfigured && (
+            <span className="text-sm font-medium text-danger">OST event metadata not found</span>
+          )}
+          <Button
+            type="button"
+            size="wide"
+            onClick={handleTogglePush}
+            disabled={!expiration || (pushPaused && !eventGroupConfigured)}
+          >
             {pushPaused ? "Resume Pushes" : "Pause Pushes"}
           </Button>
         </Stack>
@@ -285,7 +315,7 @@ export function OpenSplitTimeLogin({ className }: OpenSplitTimeLoginProps = {}) 
             />
             <span>Save credentials</span>
           </div>
-          {error && <span className="text-sm font-medium text-danger">Sign-in failed.</span>}
+          {error && <span className="text-sm font-medium text-danger">{error}</span>}
           <Button type="submit" size="wide" disabled={isSubmitting}>
             {isSubmitting ? "Signing In..." : "Sign In"}
           </Button>

--- a/src/renderer/src/features/SettingsPage/hooks/useSettingsMutations.tsx
+++ b/src/renderer/src/features/SettingsPage/hooks/useSettingsMutations.tsx
@@ -11,7 +11,8 @@ export function useSettingsMutations() {
   });
 
   const importStationsFile = useBasicIpcCall("load-stations-file", {
-    preToast: "Loading Stations file"
+    preToast: "Loading Stations file",
+    invalidateQueryKeys: [["opensplittime-event-group-configured"]]
   });
 
   const importDNSFile = useBasicIpcCall("load-dns-file", {

--- a/src/renderer/src/hooks/ipc/useBasicIpcCall.tsx
+++ b/src/renderer/src/hooks/ipc/useBasicIpcCall.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { QueryKey, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToasts } from "~/features/Toasts/useToasts";
 import { Toast } from "$shared/types";
 import { useIpcRenderer } from "../useIpcRenderer";
@@ -6,10 +6,12 @@ import { useIpcRenderer } from "../useIpcRenderer";
 interface Options {
   preToast?: string | Toast;
   successToastType?: Toast["type"];
+  invalidateQueryKeys?: QueryKey[];
 }
 
 export function useBasicIpcCall(channel: string, options: Options = {}) {
   const ipcRenderer = useIpcRenderer();
+  const queryClient = useQueryClient();
   const { createToast } = useToasts();
 
   return useMutation({
@@ -24,8 +26,12 @@ export function useBasicIpcCall(channel: string, options: Options = {}) {
 
       return ipcRenderer.invoke(channel);
     },
-    onSuccess: (data) =>
-      createToast({ message: data, type: options.successToastType ?? "success" }),
+    onSuccess: (data) => {
+      createToast({ message: data, type: options.successToastType ?? "success" });
+      options.invalidateQueryKeys?.forEach((queryKey) => {
+        queryClient.invalidateQueries({ queryKey });
+      });
+    },
     onError: (error) => console.error(error)
   });
 }


### PR DESCRIPTION
## Summary
Pushing timing records to OpenSplitTime (OST) could fail with a confusing "record not found" 404 because the app silently fell back to using the generic race event name (e.g. `bear-100-2026`) as the OST event-group slug when the environment-specific OST slug wasn't configured, instead of the real per-environment OST slug (e.g. `bear-100-test` for staging, `the-bear-100-2026` for production).

## Changes
- **Main process**:
  - `stations-db.ts`: stopped conflating the generic `event.name` config value with the staging OST event-group slug when loading a stations file.
  - `opensplittime.ts`: removed the unsafe fallback to `event.name` for resolving the OST event-group slug; added `isOpenSplitTimeEventGroupConfigured()`; sign-in no longer auto-unpauses pushes when no OST event group is configured for the current environment, and manual "Resume Pushes" is blocked with a clear error in that case.
  - `opensplittime-ipc.ts`: added `opensplittime-get-event-group-configured` IPC handler.
- **Renderer**:
  - `OpenSplitTimeLogin.tsx`: shows the actual error message on sign-in/push-toggle failure instead of a generic "Sign-in failed."; added a query-backed `eventGroupConfigured` status (refetches on mount/remount and environment change) that disables the "Resume Pushes" button and shows an "OST event metadata not found" label when the current environment has no configured OST event group.
  - `useBasicIpcCall.tsx`: added an `invalidateQueryKeys` option so a mutation can invalidate other react-query caches on success.
  - `useSettingsMutations.tsx`: `importStationsFile` now invalidates the OST event-group-configured query on success so the UI updates immediately after loading a new stations file.
- **Config**: documented the OST event metadata fields (production/staging name+id, splitNames) in `stations-template.json`.

## Testing
- Not run as part of this workflow step; validated in the implementation session.
