### PR TITLE
refactor: unify DNS/DNF to DropReason and CSV Drops file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ out
 /Database/
 opensplittime.env
 rfid.env
+resources/ost-api-responses/
+resources/dns-dnf-files/

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ For a guide on how to set up an event using Ultra-Tracker, visit the project [Wi
 2. Load the Stations file
    1. Select Station location and set operator call sign
 3. Load the Athletes file
-4. Load the Did Not Start (DNS) File
-5. Load the most recent Did Not Finish (DNF) file
-6. Go to stats screen and begin logging athletes
+4. Load the Drops file (athletes known to have Not Started or Dropped from the race)
+5. Go to stats screen and begin logging athletes
 
 ## Navigation Sidebar
 
@@ -46,7 +45,7 @@ A Filter control for any column can be opened by clicking the Filter icon (three
 
 To edit a timing record, click on the icon at the far-right side of the record row.
 
-The Edit pane allows modification or deletion of a timing record. The In and Out times, DNF and DNS status, and any notes that have been entered will be displayed. Changes to these fields must be applied to take effect, or cancelled to return to the Stats page.
+The Edit pane allows modification or deletion of a timing record. The In and Out times, Drop Reason, and any notes that have been entered will be displayed. Changes to these fields must be applied to take effect, or cancelled to return to the Stats page.
 
 If the Bib# can be matched with known athlete, the athlete's name will be displayed. The button above the name will jump to that athlete in the Roster page. A timing record for an unknown athlete is considered a warning condition, as all athletes should be known and checked in at the Start of the event, and included in the Athletes file. For a timing record not matched to athlete, limited changes can be performed, resolve the Bib# to a known athlete to modify all values.
 
@@ -128,7 +127,7 @@ Timing record indicators show the current delivery state:
 | OpenSplitTime | <img src="src/renderer/public/img/status/upload-failed.svg" alt="Red solid circle" width="16"> | Upload failed |
 
 - **Export Incremental CSV File**
-  This function exports a `.csv` file of the station entries containing unsent or edited records, contains BibID, TimeIn, TimeOut, DNF/DNS status and any notes made by the operator. The exported file will be automatically named and incremented. e.g. `Aid05Times_04i.csv, Aid05Times_05i.csv, and Aid05Times_06i.csv`.
+  This function exports a `.csv` file of the station entries containing unsent or edited records, contains BibID, TimeIn, TimeOut, Drop Reason and any notes made by the operator. The exported file will be automatically named and incremented. e.g. `Aid05Times_04i.csv, Aid05Times_05i.csv, and Aid05Times_06i.csv`.
 
   Sending recent time records in smaller batches allows for much smaller files being routinely sent to race leadership to import to the race timing site, whether by packet radio or internet. This keeps timing data updated timely for athlete support crews and other situation in an event. Depending on the rate of athletes arriving and departing a station, sending an incremental file _every 30 minutes at a minimim_ is recommended, more often if possible.
 
@@ -138,15 +137,12 @@ Timing record indicators show the current delivery state:
   > All Incremental files must be transmitted to the race leadership as each file only contains a portion of the overall station data.
 
 - **Export Full CSV File**
-  This function exports a full `.csv` file of **all time records** containing TimeIn, TimeOut, DNF/DNS status and any notes made by the station operators.
+  This function exports a full `.csv` file of **all time records** containing TimeIn, TimeOut, Drop Reason and any notes made by the station operators.
 
 This file is useful as a final station report.
 
-- **Export DNS File**
-  This function exports a `.csv` file with all DNS entries that have occurred at the current station. This is unlikely to be used at any station other than the Start Line.
-
-- **Export DNF File**
-  This function exports a `.csv` file with all DNF entries that have occurred up to the current station. This file is not normally needed to be sent to race organizers but can be an efficient way of sending the current station's DNF list to another station.
+- **Export Drops File**
+  This function exports a `.csv` file with all Drop entries (Not Started, Withdrew, Timeout, Medical, Unknown) that have occurred at or before the current station. This file is not normally needed to be sent to race organizers but can be an efficient way of sending the current station's Drops list to another station.
 
 ## Theme Page
 
@@ -184,14 +180,12 @@ The following is a description of each button's function. Each of these will ope
   This loads a `JSON` file containing each of the stations and their detailed information to allow ease of selection while setting up this application. A typical filename will be `eventname-YYYY-stations.json`.
 - **Load Athletes File**
   This function loads a `.csv` file, supplied by race organizers, containing all athletes registered or checked in for the event, whether they are known to have started _or not_.
-- **Load DNS File**
-  This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** the race.
-- **Load DNF File**
-  This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not finished** the race.
+- **Load Drops File**
+  This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** or **dropped from** the race (Withdrew, Timeout, Medical, Unknown).
 
-  As an event proceeds more DNF athletes will be recorded and new DNF files will be supplied to stations.
+  As an event proceeds more Drops will be recorded and new Drops files will be supplied to stations.
 
-  Importing new DNF files will update all athletes recorded and DNF earlier in the race, DNFs past the current station are ignored. This provides insight of which athletes are still expected into the current station.
+  Importing new Drops files will update all athletes recorded as dropped at or before the current station; drops past the current station are ignored. This provides insight of which athletes are still expected into the current station.
 
 #### RFID Configuration
 
@@ -221,8 +215,7 @@ The following is a description of each button's function. Each of these will ope
 >
 > 1. Load the Stations file.
 > 1. Load the Athletes file.
-> 1. Load the DNS file.
-> 1. Load the most recent DNF file.
+> 1. Load the Drops file.
 > 1. Import a Full Export file using "Recover Data From CSV File".
 
 ### Local Database

--- a/src/main/database/athlete-db.ts
+++ b/src/main/database/athlete-db.ts
@@ -25,7 +25,7 @@ export async function LoadAthletes() {
     "emergencyPhone"
   ];
 
-  // this is entirely destructive, will lose any notes and DNS/DNF tags that aren't saved to a file.
+  // this is entirely destructive, will lose any notes and Drop tags that aren't saved to a file.
   clearAthletesTable();
   createAthletesTable();
 
@@ -98,7 +98,7 @@ export function GetAthletes(): DatabaseResponse<AthleteStatusDB[]> {
   try {
     queryResult = db
       .prepare(
-        `SELECT Athletes.*, Status.dns, Status.dnf, Status.dnfType, Status.note, Status.progress
+        `SELECT Athletes.*, Status.dropped, Status.dropReason, Status.note, Status.progress
          FROM Athletes LEFT JOIN Status
          WHERE Athletes.bibId == Status.bibId`
       )

--- a/src/main/database/athlete-db.ts
+++ b/src/main/database/athlete-db.ts
@@ -99,8 +99,7 @@ export function GetAthletes(): DatabaseResponse<AthleteStatusDB[]> {
     queryResult = db
       .prepare(
         `SELECT Athletes.*, Status.dropped, Status.dropReason, Status.note, Status.progress
-         FROM Athletes LEFT JOIN Status
-         WHERE Athletes.bibId == Status.bibId`
+         FROM Athletes LEFT JOIN Status ON Athletes.bibId == Status.bibId`
       )
       .all();
   } catch (e) {

--- a/src/main/database/migrations-db.ts
+++ b/src/main/database/migrations-db.ts
@@ -2,6 +2,7 @@ import { IMigration } from "@blackglory/better-sqlite3-migrations";
 import * as tableDefs0 from "./schema/table-definitions-v0";
 import * as tableDefs2 from "./schema/table-definitions-v2";
 import * as tableDefs3 from "./schema/table-definitions-v3";
+import * as tableDefs4 from "./schema/table-definitions-v4";
 
 export const migrations: IMigration[] = [
   {
@@ -67,6 +68,40 @@ export const migrations: IMigration[] = [
         DROP TABLE IF EXISTS RFIDInbox;
         DROP TABLE IF EXISTS RFIDPendingWrites;
         DROP TABLE IF EXISTS OpenSplitTimePushStatus;
+      `
+  },
+  {
+    version: 4,
+    up: `
+        CREATE TABLE IF NOT EXISTS Status_v4 (
+          "index" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, ${tableDefs4.Status});
+        INSERT INTO Status_v4 (bibId, dropped, dropReason, dropStation, dropDateTime, note, progress)
+          SELECT bibId,
+            CASE WHEN dns = 1 OR dnf = 1 THEN 1 ELSE 0 END,
+            CASE WHEN dns = 1 THEN 'did-not-start' WHEN dnf = 1 THEN dnfType ELSE NULL END,
+            CASE WHEN dnf = 1 THEN dnfStation ELSE NULL END,
+            CASE WHEN dnf = 1 THEN dnfDateTime ELSE NULL END,
+            note, progress
+          FROM Status
+          WHERE EXISTS (SELECT 1 FROM Status LIMIT 1);
+        DROP TABLE Status;
+        ALTER TABLE Status_v4 RENAME TO Status;
+      `,
+    down: `
+        CREATE TABLE IF NOT EXISTS Status_v2 (
+          "index" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, ${tableDefs2.Status});
+        INSERT INTO Status_v2 (bibId, dns, dnf, dnfType, dnfStation, dnfDateTime, note, progress)
+          SELECT bibId,
+            CASE WHEN dropReason = 'did-not-start' THEN 1 ELSE 0 END,
+            CASE WHEN dropped = 1 AND dropReason != 'did-not-start' THEN 1 ELSE 0 END,
+            CASE WHEN dropReason != 'did-not-start' THEN dropReason ELSE NULL END,
+            dropStation,
+            dropDateTime,
+            note, progress
+          FROM Status
+          WHERE EXISTS (SELECT 1 FROM Status LIMIT 1);
+        DROP TABLE Status;
+        ALTER TABLE Status_v2 RENAME TO Status;
       `
   }
 ];

--- a/src/main/database/runners-db.ts
+++ b/src/main/database/runners-db.ts
@@ -2,11 +2,11 @@ import fs from "fs";
 import { finished } from "stream/promises";
 import { parse } from "csv-parse";
 import { format } from "date-fns";
-import { DNFType, DatabaseStatus, RecordStatus } from "$shared/enums";
+import { DatabaseStatus, DropReason, RecordStatus } from "$shared/enums";
 import { RunnerAthleteDB, RunnerDB } from "$shared/models";
 import { DatabaseResponse } from "$shared/types";
 import { getDatabaseConnection } from "./connect-db";
-import { SetDNF } from "./status-db";
+import { SetDrop } from "./status-db";
 import { insertOrUpdateTimeRecord, markTimeRecordAsSent } from "./timingRecords-db";
 import { sendToastToRenderer } from "../ipc/toast-ipc";
 import * as dialogs from "../lib/file-dialogs";
@@ -40,8 +40,8 @@ export function GetRunnersWithDuplicateStatus(): number {
   return count[0] == null ? invalidResult : count[0];
 }
 
-export function GetDNSRunnersInStation(): number {
-  const count = getDNSRunnersInStation();
+export function GetDidNotStartRunnersInStation(): number {
+  const count = getDidNotStartRunnersInStation();
   return count[0] == null ? invalidResult : count[0];
 }
 
@@ -159,7 +159,7 @@ function getUnknownRunners(): DatabaseResponse<number> {
   return [queryResult.length as number, DatabaseStatus.Success, message];
 }
 
-function getDNSRunnersInStation(): DatabaseResponse<number> {
+function getDidNotStartRunnersInStation(): DatabaseResponse<number> {
   let stationId = -1;
   try {
     stationId = appStore.get("station.id") as number;
@@ -173,10 +173,10 @@ function getDNSRunnersInStation(): DatabaseResponse<number> {
   let message: string = "";
   let queryResult;
 
-  const stmt = `SELECT TimeRecords.*, Status.dnf, Status.dnfType, Status.dns
+  const stmt = `SELECT TimeRecords.*, Status.dropped, Status.dropReason
        FROM "TimeRecords" LEFT JOIN "Status"
        ON TimeRecords.bibId = Status.bibId
-       WHERE Status.dns == 1 and TimeRecords.stationId == ?`;
+       WHERE Status.dropReason == '${DropReason.DidNotStart}' and TimeRecords.stationId == ?`;
   try {
     queryResult = db.prepare(stmt).all(stationId);
   } catch (e) {
@@ -188,12 +188,12 @@ function getDNSRunnersInStation(): DatabaseResponse<number> {
 
   if (queryResult == null) return [null, DatabaseStatus.NotFound, message];
 
-  message = `GetRunnersInStation From TimeRecords Where 'Status.dns == 1 and TimeRecords.stationId == ${stationId}':${queryResult.length}`;
+  message = `GetRunnersInStation From TimeRecords Where 'Status.dropReason == did-not-start and TimeRecords.stationId == ${stationId}':${queryResult.length}`;
 
   return [queryResult.length as number, DatabaseStatus.Success, message];
 }
 
-function getRunnersWithDNFNotSent(): DatabaseResponse<DNFRunnerDB> {
+function getRunnersWithDropNotSent(): DatabaseResponse<DropRunnerDB> {
   const db = getDatabaseConnection();
   let queryResult;
   let message: string = "";
@@ -201,7 +201,7 @@ function getRunnersWithDNFNotSent(): DatabaseResponse<DNFRunnerDB> {
   try {
     queryResult = db
       .prepare(
-        `SELECT TimeRecords.*, Status.dnf, Status.dnfType, Status.dnfStation, Status.dnfDateTime, Status.dns
+        `SELECT TimeRecords.*, Status.dropped, Status.dropReason, Status.dropStation, Status.dropDateTime
         FROM "TimeRecords" LEFT JOIN "Status"
         ON TimeRecords.bibId = Status.bibId WHERE sent == 0`
       )
@@ -220,14 +220,14 @@ function getRunnersWithDNFNotSent(): DatabaseResponse<DNFRunnerDB> {
 }
 
 export function readRunnersTable<T>(
-  includeDNF: T
+  includeDrops: T
 ): T extends true ? DatabaseResponse<RunnerAthleteDB[]> : DatabaseResponse<RunnerDB[]> {
   const db = getDatabaseConnection();
   let queryResult;
   let message: string = "";
 
-  const statement = includeDNF
-    ? `SELECT TimeRecords.*, Status.dnf, Status.dnfType, Status.dns
+  const statement = includeDrops
+    ? `SELECT TimeRecords.*, Status.dropped, Status.dropReason
        FROM "TimeRecords" LEFT JOIN "Status"
        ON TimeRecords.bibId = Status.bibId`
     : `SELECT * FROM TimeRecords`;
@@ -254,7 +254,16 @@ export function readRunnersTable<T>(
 }
 
 export async function importRunnersFromCSV() {
-  const headers = ["index", "sent", "bibId", "timeIn", "timeOut", "dnfType", "dnfStation", "note"];
+  const headers = [
+    "index",
+    "sent",
+    "bibId",
+    "timeIn",
+    "timeOut",
+    "dropReason",
+    "dropStation",
+    "note"
+  ];
   const runnerCSVFilePath = await dialogs.loadRunnersFromCSV();
   const fileContent = fs.createReadStream(runnerCSVFilePath[0], { encoding: "utf-8" });
   const stationId = (await appStore.get("station.id")) as number;
@@ -269,7 +278,7 @@ export async function importRunnersFromCSV() {
       })
     )
     .on("data", (timing) => {
-      const record: DNFRunnerDB = {
+      const record: DropRunnerDB = {
         index: timing.bibId,
         bibId: Number(timing.bibId) - Number(timing.bibId % 1),
         stationId: stationId,
@@ -279,10 +288,10 @@ export async function importRunnersFromCSV() {
         note: !timing.note ? "" : timing.note.replaceAll(",", ""),
         sent: false,
         status: timing.bibId % 1 == 0 ? RecordStatus.OK : RecordStatus.Duplicate,
-        dnf: Number(timing.dnfType != ""),
-        dnfType: timing.dnfType,
-        dnfStation: timing.dnfStation,
-        dnfDateTime: timing.timeOut == "" ? null : parseCSVDate(timing.timeOut)
+        dropped: Number(timing.dropReason != ""),
+        dropReason: timing.dropReason,
+        dropStation: timing.dropStation,
+        dropDateTime: timing.timeOut == "" ? null : parseCSVDate(timing.timeOut)
       };
 
       function enumFromStringValue<T>(enm: { [s: string]: T }, value: string): T | undefined {
@@ -292,14 +301,14 @@ export async function importRunnersFromCSV() {
       }
 
       insertOrUpdateTimeRecord(record);
-      if (record.dnf) {
-        const dnfType = enumFromStringValue(DNFType, record.dnfType);
-        SetDNF(record.bibId, record.timeOut, Boolean(record.dnf), dnfType!);
+      if (record.dropped) {
+        const dropReason = enumFromStringValue(DropReason, record.dropReason);
+        SetDrop(record.bibId, record.timeOut, Boolean(record.dropped), dropReason!);
       }
     })
     .on("error", (error) => {
       console.error(error);
-      message = `Loading dnfRecords: ${error.message}`;
+      message = `Loading dropRecords: ${error.message}`;
       sendToastToRenderer({ message: error.message, type: "danger" });
     });
   await finished(parser);
@@ -333,7 +342,7 @@ export function exportUnsentRunnersAsCSV() {
   if (filePath == undefined) return "Invalid file name";
 
   try {
-    queryResult = getRunnersWithDNFNotSent()[0];
+    queryResult = getRunnersWithDropNotSent()[0];
     if (queryResult == null) return `Failed to get unsent runners`;
 
     if (queryResult.length == 0) {
@@ -382,7 +391,7 @@ export async function exportRunnersAsCSV() {
   try {
     queryResult = db
       .prepare(
-        `SELECT TimeRecords.*, Status.dnf, Status.dnfType, Status.dnfStation, Status.dnfDateTime, Status.dns
+        `SELECT TimeRecords.*, Status.dropped, Status.dropReason, Status.dropStation, Status.dropDateTime
         FROM "TimeRecords" LEFT JOIN "Status"
         ON TimeRecords.bibId = Status.bibId`
       )
@@ -401,51 +410,30 @@ export async function exportRunnersAsCSV() {
   return `File Export Successful: ${filename}`;
 }
 
-export async function exportDNSAsCSV() {
-  const db = getDatabaseConnection();
-  let queryResult;
-  let filename: string = "";
-
-  const stmt = `SELECT * FROM Status WHERE dns == 1`;
-
-  try {
-    queryResult = db.prepare(stmt).all();
-    filename = await dialogs.saveDNSRunnersToCSV();
-
-    if (filename == undefined) return "Invalid file name";
-
-    writeDNSToCSV(filename, queryResult);
-  } catch (e) {
-    if (e instanceof Error) {
-      console.error(e.message);
-      return e.message;
-    }
-  }
-  return `File Export Successful: ${filename}`;
-}
-
-export async function exportDNFAsCSV() {
+export async function exportDropsAsCSV() {
   const db = getDatabaseConnection();
   let queryResult;
   let filename: string = "";
   const stationId = appStore.get("station.id") as number;
 
   const stmt = `
-    SELECT t1.bibId AS dnfBibId, t1.dnf, t1.dnfType, t1.dnfStation, t1.dnfDateTime, t2.*
+    SELECT t1.bibId AS dropBibId, t1.dropped, t1.dropReason, t1.dropStation, t1.dropDateTime,
+           COALESCE(t2.note, t1.note) AS note
     FROM Status t1 LEFT JOIN TimeRecords t2
     ON t1.bibId = t2.bibId
-    WHERE t1.dnf == 1
+    WHERE t1.dropped == 1
   `;
 
   try {
-    const dnfRows = db.prepare(stmt).all() as DNFExportRow[];
-    queryResult = dnfRows
-      .filter((row) => Number(String(row.dnfStation).split("-", 1)[0]) <= stationId);
-    filename = await dialogs.saveDNFRunnersToCSV();
+    const dropRows = db.prepare(stmt).all() as DropExportRow[];
+    queryResult = dropRows.filter(
+      (row) => Number(String(row.dropStation).split("-", 1)[0]) <= stationId
+    );
+    filename = await dialogs.saveDropsToCSV();
 
     if (filename == undefined) return "Invalid file name";
 
-    writeDNFToCSV(filename, queryResult);
+    writeDropsToCSV(filename, queryResult);
   } catch (e) {
     if (e instanceof Error) {
       console.error(e.message);
@@ -468,10 +456,10 @@ function writeToCSV(filename: string, queryResult, incremental: boolean) {
     stream.write(titleText + "\n");
 
     // header row
-    const headerText = `index,sent,bibId,timeIn,timeOut,dnfType,dnfStation,note`;
+    const headerText = `index,sent,bibId,timeIn,timeOut,dropReason,dropStation,note`;
     stream.write(headerText + "\n");
 
-    for (const row of queryResult as DNFRunnerDB[]) {
+    for (const row of queryResult as DropRunnerDB[]) {
       let rowText = "";
       const bSent = Boolean(row.sent);
       if (!incremental || (incremental && !bSent)) {
@@ -482,8 +470,8 @@ function writeToCSV(filename: string, queryResult, incremental: boolean) {
           `${row.bibId},` +
           `${row.timeIn == null ? "" : formatDate(new Date(row.timeIn))},` +
           `${row.timeOut == null ? "" : formatDate(new Date(row.timeOut))},` +
-          `${row.dnfType == null ? "" : row.dnfType},` +
-          `${row.dnfStation == null ? "" : row.dnfStation},` +
+          `${row.dropReason == null ? "" : row.dropReason},` +
+          `${row.dropStation == null ? "" : row.dropStation},` +
           `${row.note == null ? "" : row.note}`;
         stream.write(rowText + "\n");
       }
@@ -493,56 +481,27 @@ function writeToCSV(filename: string, queryResult, incremental: boolean) {
   });
 }
 
-interface DNFRunnerDB extends RunnerDB {
-  dnf: number;
-  dnfType: string;
-  dnfStation: string;
-  dnfDateTime: Date | null;
+interface DropRunnerDB extends RunnerDB {
+  dropped: number;
+  dropReason: string;
+  dropStation: string;
+  dropDateTime: Date | null;
 }
 
-interface DNFExportRow extends DNFRunnerDB {
-  dnfBibId: number;
+interface DropExportRow {
+  dropBibId: number;
+  dropped: number;
+  dropReason: string;
+  dropStation: string;
+  dropDateTime: Date | null;
+  note: string;
 }
 
-function normalizeExportNote(note: string | null | undefined): string {
-  return note ?? "";
+function sanitizeNoteForExport(note: string | null | undefined): string {
+  return (note ?? "").replaceAll(",", ";");
 }
 
-function writeDNSToCSV(filename: string, queryResult) {
-  const fs = require("fs");
-  const eventName = appStore.get("event.name") as string;
-  const eventStartTime = appStore.get("event.starttime") as string;
-  const stationIdentifier = appStore.get("station.identifier") as string;
-  const startLineIdentifier = appStore.get("event.startline") as string;
-
-  return new Promise((resolve, reject) => {
-    const stream = fs.createWriteStream(filename);
-
-    // title row
-    const headerText = `${eventName},${stationIdentifier},dns-export`;
-    stream.write(headerText + "\n");
-
-    // header row
-    // stationId,bibId,dnsDateTime,note
-    const columnNames = ["stationId", "bibId", "dnsDateTime", "note"];
-    const rowText = `${columnNames[0]},${columnNames[1]},${columnNames[2]},${columnNames[3]}`;
-    stream.write(rowText + "\n");
-
-    for (const row of queryResult as RunnerDB[]) {
-      let rowText = "";
-      rowText =
-        `${startLineIdentifier},` +
-        `${row.bibId},` +
-        `${eventStartTime == null ? "" : eventStartTime},` +
-        `${normalizeExportNote(row.note)}`;
-      stream.write(rowText + "\n");
-    }
-    stream.on("error", reject);
-    stream.end(resolve);
-  });
-}
-
-function writeDNFToCSV(filename: string, queryResult) {
+function writeDropsToCSV(filename: string, queryResult) {
   const fs = require("fs");
   const eventName = appStore.get("event.name") as string;
   const stationIdentifier = appStore.get("station.identifier") as string;
@@ -551,23 +510,23 @@ function writeDNFToCSV(filename: string, queryResult) {
     const stream = fs.createWriteStream(filename);
 
     // title row
-    const headerText = `${eventName},${stationIdentifier},dnf-export`;
+    const headerText = `${eventName},${stationIdentifier},drops-export`;
     stream.write(headerText + "\n");
 
     // header row
-    // stationId,bibId,dnfType,dnfDateTime,note
-    const columnNames = ["stationId", "bibId", "dnfType", "dnfDateTime", "note"];
+    // stationId,bibId,dropReason,dropDateTime,note
+    const columnNames = ["stationId", "bibId", "dropReason", "dropDateTime", "note"];
     const rowText = `${columnNames[0]},${columnNames[1]},${columnNames[2]},${columnNames[3]},${columnNames[4]}`;
     stream.write(rowText + "\n");
 
-    for (const row of queryResult as DNFExportRow[]) {
+    for (const row of queryResult as DropExportRow[]) {
       let rowText = "";
       rowText =
-        `${row.dnfStation},` +
-        `${row.dnfBibId},` +
-        `${row.dnfType},` +
-        `${row.dnfDateTime == null ? "" : formatDate(row.dnfDateTime)},` +
-        `${normalizeExportNote(row.note)}`;
+        `${row.dropStation},` +
+        `${row.dropBibId},` +
+        `${row.dropReason},` +
+        `${row.dropDateTime == null ? "" : formatDate(row.dropDateTime)},` +
+        `${sanitizeNoteForExport(row.note)}`;
       stream.write(rowText + "\n");
     }
     stream.on("error", reject);

--- a/src/main/database/runners-db.ts
+++ b/src/main/database/runners-db.ts
@@ -285,7 +285,7 @@ export async function importRunnersFromCSV() {
         timeIn: timing.timeIn == "" ? null : parseCSVDate(timing.timeIn),
         timeOut: timing.timeOut == "" ? null : parseCSVDate(timing.timeOut),
         timeModified: new Date(),
-        note: !timing.note ? "" : timing.note.replaceAll(",", ""),
+        note: !timing.note ? "" : timing.note.replaceAll(",", ";"),
         sent: false,
         status: timing.bibId % 1 == 0 ? RecordStatus.OK : RecordStatus.Duplicate,
         dropped: Number(timing.dropReason != ""),

--- a/src/main/database/schema/table-definitions-v4.ts
+++ b/src/main/database/schema/table-definitions-v4.ts
@@ -1,0 +1,36 @@
+export const expectedTableNames = {
+  Athletes: "Athletes",
+  EventLog: "EventLog",
+  Output: "Output",
+  OpenSplitTimePushStatus: "OpenSplitTimePushStatus",
+  Stations: "Stations",
+  Status: "Status",
+  TimeRecords: "TimeRecords",
+  RFIDInbox: "RFIDInbox",
+  RFIDPendingWrites: "RFIDPendingWrites"
+};
+
+export const Version = 4;
+
+export {
+  Athletes,
+  EventLog,
+  Output,
+  OpenSplitTimePushStatus,
+  Stations,
+  TimeRecords,
+  RFIDInbox,
+  RFIDPendingWrites
+} from "./table-definitions-v3";
+
+/*  The Status table is used to store the status of an athlete independent of other table operations.
+    "dns"/"dnf"/"dnfType" are unified here into a single "dropped"/"dropReason" pair, where
+    DidNotStart is just another drop reason. */
+export const Status: string = `
+      bibId INTEGER DEFAULT (0), -- TODO: Index,
+      dropped INTEGER, -- TODO: Index
+      dropReason TEXT,
+      dropStation TEXT, -- TODO: Index
+      dropDateTime DATETIME,
+      note TEXT,
+      progress INTEGER`;

--- a/src/main/database/status-db.ts
+++ b/src/main/database/status-db.ts
@@ -287,7 +287,7 @@ export function updateDropFromCSV(record: DropRecord): DatabaseResponse {
     );
     query.run(droppedValue, record.dropReason, record.stationId, dropDateTime, record.bibId);
 
-    syncNoteWithStatus(record.bibId, record.note, -1, SyncDirection.Outgoing);
+    syncNoteWithStatus(record.bibId, record.note.replaceAll(",", ";"), -1, SyncDirection.Outgoing);
 
     logEvent(
       record.bibId,

--- a/src/main/database/status-db.ts
+++ b/src/main/database/status-db.ts
@@ -4,8 +4,8 @@ import { parse } from "csv-parse";
 import { getDatabaseConnection } from "./connect-db";
 import { logEvent } from "./eventLogger-db";
 import { clearPushStatus } from "./opensplittimeStatus-db";
-import { AthleteProgress, DNFType, DatabaseStatus } from "../../shared/enums";
-import { DNFRecord, DNSRecord, RunnerDB, StatusDB } from "../../shared/models";
+import { AthleteProgress, DatabaseStatus, DropReason } from "../../shared/enums";
+import { DropRecord, RunnerDB, StatusDB } from "../../shared/models";
 import { DatabaseResponse } from "../../shared/types";
 import { emitRunnersTableChanged } from "../ipc/runner-data-emitter";
 import { sendToastToRenderer } from "../ipc/toast-ipc";
@@ -15,11 +15,12 @@ import { pushTimeRecordUpdate } from "../services/opensplittime";
 
 const invalidResult = -999;
 
-export async function LoadDNS() {
-  const headers = ["stationId", "bibId", "dnsDateTime", "note"];
-  const dnsFilePath = await dialogs.loadDNSFromCSV();
-  const fileContent = fs.createReadStream(dnsFilePath[0], { encoding: "utf-8" });
+export async function LoadDrops() {
+  const headers = ["stationId", "bibId", "dropReason", "dropDateTime", "note"];
+  const dropsFilePath = await dialogs.loadDropsFromCSV();
+  const fileContent = fs.createReadStream(dropsFilePath[0], { encoding: "utf-8" });
   let message: string = "";
+  let dropCount: number = 0;
 
   const parser = fileContent
     .pipe(
@@ -30,55 +31,24 @@ export async function LoadDNS() {
       })
     )
     .on("data", (row) => {
-      updateDNSFromCSV(row);
-    })
-    .on("error", (error) => {
-      console.error(error);
-      message = `Loading dnsRecords: ${error.message}`;
-      sendToastToRenderer({ message: error.message, type: "danger" });
-    })
-    .on("end", () => {
-      const { records } = parser.info;
-      message = `${dnsFilePath}\r\n${records} dnsRecords imported`;
-    });
-  await finished(parser);
-
-  return message;
-}
-
-export async function LoadDNF() {
-  const headers = ["stationId", "bibId", "dnfType", "dnfDateTime", "note"];
-  const dnfFilePath = await dialogs.loadDNFFromCSV();
-  const fileContent = fs.createReadStream(dnfFilePath[0], { encoding: "utf-8" });
-  let message: string = "";
-  let dnfCount: number = 0;
-
-  const parser = fileContent
-    .pipe(
-      parse({
-        delimiter: ",",
-        columns: headers,
-        fromLine: 3
-      })
-    )
-    .on("data", (row) => {
-      // load dnf into current station only if from earlier or current
-      const dnfStationId = Number(row.stationId.split("-", 1)[0]);
+      // load a drop into the current station only if it occurred at an earlier or the current
+      // station; the start-line is station 0, so did-not-start rows always pass this check
+      const dropStationId = Number(row.stationId.split("-", 1)[0]);
       const stationId = appStore.get("station.id") as number;
 
-      if (dnfStationId <= stationId) {
-        updateDNFFromCSV({ ...row, stationIdentifier: row.stationId });
-        dnfCount++;
+      if (dropStationId <= stationId) {
+        updateDropFromCSV(row);
+        dropCount++;
       }
     })
     .on("error", (error) => {
       console.error(error);
-      message = `Loading dnfRecords: ${error.message}`;
+      message = `Loading dropRecords: ${error.message}`;
       sendToastToRenderer({ message: error.message, type: "danger" });
     })
     .on("end", () => {
       const { records } = parser.info;
-      message = `${dnfFilePath}\r\n${records} dnfRecords processed, ${dnfCount} imported`;
+      message = `${dropsFilePath}\r\n${records} dropRecords processed, ${dropCount} imported`;
     });
   await finished(parser);
 
@@ -89,13 +59,13 @@ export function GetStatusByBib(bibNumber: number): [StatusDB | null, DatabaseSta
   return GetStatusFromColumn("bibId", bibNumber);
 }
 
-// A runner is "stopped here" for OST purposes when they have an active DNF recorded at the current station.
+// A runner is "stopped here" for OST purposes when they have an active drop recorded at the current station.
 export function getStoppedHereForBib(bibId: number): boolean {
   const [status] = GetStatusByBib(bibId);
-  if (!status?.dnf) return false;
+  if (!status?.dropped) return false;
 
   const stationIdentifier = appStore.get("station.identifier") as string;
-  return status.dnfStation === stationIdentifier;
+  return status.dropStation === stationIdentifier;
 }
 
 export function GetStatusFromColumn(
@@ -127,11 +97,10 @@ export function GetStatusFromColumn(
   // map result to athlete object
   const athleteStatus: StatusDB = {
     bibId: queryResult.bibId,
-    dns: queryResult.dns,
-    dnf: queryResult.dnf,
-    dnfType: queryResult.dnfType,
-    dnfStation: queryResult.dnfStation,
-    dnfDateTime: queryResult.dnfDateTime,
+    dropped: queryResult.dropped,
+    dropReason: queryResult.dropReason,
+    dropStation: queryResult.dropStation,
+    dropDateTime: queryResult.dropDateTime,
     note: queryResult.note,
     progress: queryResult.progress
   };
@@ -141,17 +110,17 @@ export function GetStatusFromColumn(
   return [athleteStatus, DatabaseStatus.Success, message];
 }
 
-export function GetTotalDNS(): number {
-  const count = GetStatusCount("dns", `dns == 1`);
+export function GetTotalDidNotStart(): number {
+  const count = GetStatusCount("dropReason", `dropReason == '${DropReason.DidNotStart}'`);
   return count[0] == null ? invalidResult : count[0];
 }
 
-export function GetTotalDNF(): number {
-  const count = GetStatusCount("dnf", `dnf == ${Number(true)}`);
+export function GetTotalDropped(): number {
+  const count = GetStatusCount("dropped", `dropped == ${Number(true)}`);
   return count[0] == null ? invalidResult : count[0];
 }
 
-export function GetStationDNF(): number {
+export function GetStationDropped(): number {
   let stationIdentifier: string | null = null;
   try {
     stationIdentifier = appStore.get("station.identifier") as string;
@@ -161,11 +130,11 @@ export function GetStationDNF(): number {
 
   if (!stationIdentifier) return invalidResult;
 
-  const count = GetStatusCount("dnf", `dnfStation == '${stationIdentifier}'`);
+  const count = GetStatusCount("dropped", `dropStation == '${stationIdentifier}'`);
   return count[0] == null ? invalidResult : count[0];
 }
 
-export function GetPreviousDNF(): number {
+export function GetPreviousDropped(): number {
   const db = getDatabaseConnection();
   let stationId: number | null = null;
 
@@ -180,7 +149,7 @@ export function GetPreviousDNF(): number {
   let queryResult;
 
   try {
-    queryResult = db.prepare(`SELECT * FROM Status WHERE dnf == ?`).all(Number(true));
+    queryResult = db.prepare(`SELECT * FROM Status WHERE dropped == ?`).all(Number(true));
   } catch (e) {
     if (e instanceof Error) {
       console.error(e.message);
@@ -190,24 +159,46 @@ export function GetPreviousDNF(): number {
 
   if (queryResult == null) return invalidResult;
 
-  const dnfList = queryResult as StatusDB[];
-  const previousDNF: StatusDB[] = [];
+  const droppedList = queryResult as StatusDB[];
+  const previousDropped: StatusDB[] = [];
 
-  for (const record of dnfList) {
-    const id = Number(record.dnfStation?.split("-", 1)[0]);
-    if (id < stationId) previousDNF.push(record);
+  for (const record of droppedList) {
+    const id = Number(record.dropStation?.split("-", 1)[0]);
+    if (id < stationId) previousDropped.push(record);
   }
 
-  return previousDNF.length == null ? invalidResult : previousDNF.length;
+  return previousDropped.length == null ? invalidResult : previousDropped.length;
 }
 
-export function SetDNS(bibId: number, dnsValue: boolean): DatabaseResponse {
+export function SetDrop(
+  bibId: number,
+  timeOut: Date | null,
+  droppedValue: boolean,
+  dropReason: DropReason
+): DatabaseResponse {
   const db = getDatabaseConnection();
   let message: string = "";
+  let stationIdentifier: string | null = appStore.get("station.identifier") as string;
+  let reason: DropReason | null = dropReason;
+  const dropDateTime = !timeOut ? new Date().toISOString() : timeOut.toISOString();
+  const timingRecord = db.prepare(`SELECT * FROM TimeRecords WHERE bibId = ?`).get(bibId) as
+    RunnerDB | undefined;
+  const previousDrop = db.prepare(`SELECT dropped FROM Status WHERE bibId = ?`).get(bibId) as
+    | {
+        dropped: number;
+      }
+    | undefined;
+
+  if (!droppedValue) {
+    stationIdentifier = null;
+    reason = null;
+  }
 
   try {
-    const query = db.prepare(`UPDATE Status SET dns = ? WHERE bibId = ?`);
-    query.run(Number(dnsValue), bibId);
+    const query = db.prepare(
+      `UPDATE Status SET dropped = ?, dropReason = ?, dropStation = ?, dropDateTime = ? WHERE bibId = ?`
+    );
+    query.run(Number(droppedValue), reason, stationIdentifier, dropDateTime, bibId);
   } catch (e) {
     if (e instanceof Error) {
       console.error(e.message);
@@ -220,13 +211,43 @@ export function SetDNS(bibId: number, dnsValue: boolean): DatabaseResponse {
     null,
     null,
     null,
-    new Date().toISOString(),
-    `[Set](DNS): bib:${bibId}, value:${dnsValue}`,
+    dropDateTime,
+    `[Set](Drop): bib:${bibId}, value:${droppedValue}`,
     false,
     false
   );
 
-  message = `status:update bibId: ${bibId}, dns: ${dnsValue}`;
+  message = `status:update bibId: ${bibId}, dropped: ${droppedValue}, dropReason: ${dropReason}`;
+
+  // Did-Not-Start drops never had a timing record, so skip the OpenSplitTime push entirely.
+  if (
+    dropReason !== DropReason.DidNotStart &&
+    timingRecord &&
+    previousDrop?.dropped !== Number(droppedValue)
+  ) {
+    // Clear the prior push outcome immediately so the UI shows "Pending" even if the push
+    // below is skipped (paused/not signed in) or takes a while to resolve.
+    db.prepare(`UPDATE TimeRecords SET sent = ? WHERE "bibId" = ?`).run(
+      Number(false),
+      timingRecord.bibId
+    );
+    clearPushStatus(bibId);
+    emitRunnersTableChanged();
+
+    void pushTimeRecordUpdate(timingRecord, droppedValue)
+      .then((outcome) => {
+        if (outcome.pushed) {
+          db.prepare(`UPDATE TimeRecords SET sent = ? WHERE "bibId" = ?`).run(
+            Number(true),
+            timingRecord.bibId
+          );
+        }
+      })
+      .catch((error: unknown) => {
+        console.error("OpenSplitTime drop update failed", error);
+      });
+  }
+
   return [DatabaseStatus.Updated, message];
 }
 
@@ -254,135 +275,27 @@ function GetStatusCount(columnName: string, whereStatement: string): DatabaseRes
   return [count, DatabaseStatus.Success, message];
 }
 
-export function SetDNF(
-  bibId: number,
-  timeOut: Date | null,
-  dnfValue: boolean,
-  dnfType: DNFType
-): DatabaseResponse {
+export function updateDropFromCSV(record: DropRecord): DatabaseResponse {
   const db = getDatabaseConnection();
-  let message: string = "";
-  let stationIdentifier: string | null = appStore.get("station.identifier") as string;
-  let dnf: DNFType | null = dnfType;
-  const dnfDateTime = !timeOut ? new Date().toISOString() : timeOut.toISOString();
-  const timingRecord = db.prepare(`SELECT * FROM TimeRecords WHERE bibId = ?`).get(bibId) as
-    RunnerDB | undefined;
-  const previousDnf = db.prepare(`SELECT dnf FROM Status WHERE bibId = ?`).get(bibId) as
-    | {
-        dnf: number;
-      }
-    | undefined;
-
-  if (!dnfValue) {
-    stationIdentifier = null;
-    dnf = null;
-  }
-
-  try {
-    const query = db.prepare(
-      `UPDATE Status SET dnf = ?, dnfType = ?, dnfStation = ?, dnfDateTime = ? WHERE bibId = ?`
-    );
-    query.run(Number(dnfValue), dnf, stationIdentifier, dnfDateTime, bibId);
-  } catch (e) {
-    if (e instanceof Error) {
-      console.error(e.message);
-      return [DatabaseStatus.Error, e.message];
-    }
-  }
-
-  logEvent(
-    bibId,
-    null,
-    null,
-    null,
-    dnfDateTime,
-    `[Set](DNF): bib:${bibId}, value:${dnfValue}`,
-    false,
-    false
-  );
-
-  message = `status:update bibId: ${bibId}, dnf: ${dnfValue}, dnfType: ${dnfType}`;
-
-  if (timingRecord && previousDnf?.dnf !== Number(dnfValue)) {
-    // Clear the prior push outcome immediately so the UI shows "Pending" even if the push
-    // below is skipped (paused/not signed in) or takes a while to resolve.
-    db.prepare(`UPDATE TimeRecords SET sent = ? WHERE "bibId" = ?`).run(
-      Number(false),
-      timingRecord.bibId
-    );
-    clearPushStatus(bibId);
-    emitRunnersTableChanged();
-
-    void pushTimeRecordUpdate(timingRecord, dnfValue)
-      .then((outcome) => {
-        if (outcome.pushed) {
-          db.prepare(`UPDATE TimeRecords SET sent = ? WHERE "bibId" = ?`).run(
-            Number(true),
-            timingRecord.bibId
-          );
-        }
-      })
-      .catch((error: unknown) => {
-        console.error("OpenSplitTime DNF update failed", error);
-      });
-  }
-
-  return [DatabaseStatus.Updated, message];
-}
-
-export function updateDNSFromCSV(record: DNSRecord): DatabaseResponse {
-  const db = getDatabaseConnection();
-  const dnsValue = true;
-  const verbose = false;
-
-  try {
-    const query = db.prepare(`UPDATE Status SET dns = ?, note = ? WHERE bibId = ?`);
-    query.run(Number(dnsValue), record.note.replaceAll(",", ""), record.bibId);
-
-    const dnsDateTime = parseCSVDate(record.dnsDateTime).toISOString();
-
-    logEvent(
-      record.bibId,
-      record.stationId,
-      null,
-      null,
-      dnsDateTime,
-      `[Set](DNS): bibId:${record.bibId} station:'${record.stationId}'`,
-      false,
-      verbose
-    );
-  } catch (e) {
-    if (e instanceof Error) {
-      console.error(e.message);
-      return [DatabaseStatus.Error, e.message];
-    }
-  }
-
-  const message = `athlete:update bibId: ${record.bibId}, dns: ${dnsValue}, note: ${record.note}`;
-  return [DatabaseStatus.Updated, message];
-}
-
-export function updateDNFFromCSV(record: DNFRecord): DatabaseResponse {
-  const db = getDatabaseConnection();
-  const dnfValue = Number(true);
-  const dnfDateTime = parseCSVDate(record.dnfDateTime).toISOString();
+  const droppedValue = Number(true);
+  const dropDateTime = parseCSVDate(record.dropDateTime).toISOString();
   const verbose = false;
 
   try {
     const query = db.prepare(
-      `UPDATE Status SET dnf = ?, dnfType = ?, dnfStation = ?, dnfDateTime = ? WHERE bibId = ?`
+      `UPDATE Status SET dropped = ?, dropReason = ?, dropStation = ?, dropDateTime = ? WHERE bibId = ?`
     );
-    query.run(dnfValue, record.dnfType, record.stationIdentifier, dnfDateTime, record.bibId);
+    query.run(droppedValue, record.dropReason, record.stationId, dropDateTime, record.bibId);
 
     syncNoteWithStatus(record.bibId, record.note, -1, SyncDirection.Outgoing);
 
     logEvent(
       record.bibId,
-      record.stationIdentifier,
+      record.stationId,
       null,
-      dnfDateTime,
-      dnfDateTime,
-      `[Set](DNF): bibId: ${record.bibId} type: '${record.dnfType}' station: '${record.stationIdentifier}' note: '${record.note}'`,
+      dropDateTime,
+      dropDateTime,
+      `[Set](Drop): bibId: ${record.bibId} reason: '${record.dropReason}' station: '${record.stationId}' note: '${record.note}'`,
       false,
       verbose
     );
@@ -393,7 +306,7 @@ export function updateDNFFromCSV(record: DNFRecord): DatabaseResponse {
     }
   }
 
-  const message = `athlete:update bibId: ${record.bibId}, dnf: ${dnfValue}, dnfStation: ${record.stationIdentifier}, dnfDateTime: ${dnfDateTime}, note: ${record.note}`;
+  const message = `athlete:update bibId: ${record.bibId}, dropped: ${droppedValue}, dropStation: ${record.stationId}, dropDateTime: ${dropDateTime}, note: ${record.note}`;
   return [DatabaseStatus.Updated, message];
 }
 
@@ -510,11 +423,10 @@ export function SetProgress(bibId: number): DatabaseResponse {
 export function initStatus(bibId: number) {
   const status: StatusDB = {
     bibId: bibId,
-    dns: false,
-    dnf: false,
-    dnfType: undefined,
-    dnfStation: undefined,
-    dnfDateTime: null,
+    dropped: false,
+    dropReason: undefined,
+    dropStation: undefined,
+    dropDateTime: null,
     note: undefined,
     progress: AthleteProgress.Incoming
   };
@@ -525,25 +437,24 @@ export function initStatus(bibId: number) {
 export function insertStatus(status: StatusDB): DatabaseResponse {
   const db = getDatabaseConnection();
   const bibId: number = status.bibId;
-  const dns: number = Number(status.dns);
-  const dnf: number = Number(status.dnf);
-  const dnfType = status.dnfType;
-  const dnfStation = status.dnfStation;
-  const dnfDateTime = status.dnfDateTime;
+  const dropped: number = Number(status.dropped);
+  const dropReason = status.dropReason;
+  const dropStation = status.dropStation;
+  const dropDateTime = status.dropDateTime;
   const note = status.note;
   const progress = status.progress;
 
   const statusRecord = GetStatusByBib(bibId);
   if (statusRecord[0] != null) {
-    const message = `status:duplicate ${bibId}, ${dns}, ${dnf}, '${note}', ${progress}`;
+    const message = `status:duplicate ${bibId}, ${dropped}, '${note}', ${progress}`;
     return [DatabaseStatus.Duplicate, message];
   }
 
   try {
     const query = db.prepare(
-      `INSERT INTO Status (bibId, dns, dnf, dnfType, dnfStation, dnfDateTime, note, progress) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO Status (bibId, dropped, dropReason, dropStation, dropDateTime, note, progress) VALUES (?, ?, ?, ?, ?, ?, ?)`
     );
-    query.run(bibId, dns, dnf, dnfType, dnfStation, dnfDateTime, note, progress);
+    query.run(bibId, dropped, dropReason, dropStation, dropDateTime, note, progress);
   } catch (e) {
     if (e instanceof Error) {
       console.error(e.message);
@@ -551,6 +462,6 @@ export function insertStatus(status: StatusDB): DatabaseResponse {
     }
   }
 
-  const message = `status:add ${bibId}, ${dns}, ${dnf}, '${note}', ${progress}`;
+  const message = `status:add ${bibId}, ${dropped}, '${note}', ${progress}`;
   return [DatabaseStatus.Created, message];
 }

--- a/src/main/database/tables-db.ts
+++ b/src/main/database/tables-db.ts
@@ -5,8 +5,9 @@ import * as tableDefs0 from "./schema/table-definitions-v0";
 import * as tableDefs1 from "./schema/table-definitions-v1";
 import * as tableDefs2 from "./schema/table-definitions-v2";
 import * as tableDefs3 from "./schema/table-definitions-v3";
+import * as tableDefs4 from "./schema/table-definitions-v4";
 
-const userVersion: number = 3;
+const userVersion: number = 4;
 let tableDefs;
 
 interface Table {
@@ -65,6 +66,10 @@ export function validateDatabaseTables() {
 
     case 3:
       tableDefs = tableDefs3;
+      break;
+
+    case 4:
+      tableDefs = tableDefs4;
       break;
   }
 

--- a/src/main/ipc/dbsettings-ipc.ts
+++ b/src/main/ipc/dbsettings-ipc.ts
@@ -17,12 +17,8 @@ const loadAthletesFile: Handler<string> = (event, args) => {
   return dbAthlete.LoadAthletes();
 };
 
-const loadDNSFile: Handler<string> = () => {
-  return dbStatus.LoadDNS();
-};
-
-const loadDNFFile: Handler<string> = () => {
-  return dbStatus.LoadDNF();
+const loadDropsFile: Handler<string> = () => {
+  return dbStatus.LoadDrops();
 };
 
 const importRunnersFile: Handler<string> = () => {
@@ -46,8 +42,7 @@ const clearDatabase: Handler<string> = () => {
 export const initdbSettingsHandlers = () => {
   ipcMain.handle("load-athletes-file", loadAthletesFile);
   ipcMain.handle("load-stations-file", loadStationFile);
-  ipcMain.handle("load-dns-file", loadDNSFile);
-  ipcMain.handle("load-dnf-file", loadDNFFile);
+  ipcMain.handle("load-drops-file", loadDropsFile);
   ipcMain.handle("import-runners-file", importRunnersFile);
   ipcMain.handle("initialize-database", initializeDatabase);
   ipcMain.handle("clear-database", clearDatabase);

--- a/src/main/ipc/export-ipc.ts
+++ b/src/main/ipc/export-ipc.ts
@@ -11,12 +11,8 @@ const exportIncrementalRunnersFile: Handler<string> = () => {
   return dbRunners.exportUnsentRunnersAsCSV();
 };
 
-const exportDNSFile: Handler<string> = () => {
-  return dbRunners.exportDNSAsCSV();
-};
-
-const exportDNFFile: Handler<string> = () => {
-  return dbRunners.exportDNFAsCSV();
+const exportDropsFile: Handler<string> = () => {
+  return dbRunners.exportDropsAsCSV();
 };
 
 const openExportDirectory = () => {
@@ -26,7 +22,6 @@ const openExportDirectory = () => {
 export const initExportHandlers = () => {
   ipcMain.handle("export-runners-file", exportRunnersFile);
   ipcMain.handle("export-incremental-file", exportIncrementalRunnersFile);
-  ipcMain.handle("export-dns-file", exportDNSFile);
-  ipcMain.handle("export-dnf-file", exportDNFFile);
+  ipcMain.handle("export-drops-file", exportDropsFile);
   ipcMain.handle("open-export-dir", openExportDirectory);
 };

--- a/src/main/ipc/runnerform-ipc.ts
+++ b/src/main/ipc/runnerform-ipc.ts
@@ -8,7 +8,7 @@ import { getOpenSplitTimePushStatus } from "../services/opensplittime";
 import { Handler } from "../types";
 
 interface GetRunnersTableOptions {
-  includeDNF: boolean;
+  includeDrops: boolean;
 }
 
 const getRunnersTable: Handler<GetRunnersTableOptions, DatabaseResponse<RunnerDB[]>> = (

--- a/src/main/ipc/status-ipc.ts
+++ b/src/main/ipc/status-ipc.ts
@@ -3,15 +3,10 @@ import { RunnerAthleteDB } from "$shared/models";
 import * as dbStatus from "../database/status-db";
 import { Handler } from "../types";
 
-const setDNS: Handler<RunnerAthleteDB> = (_, data) => {
-  return dbStatus.SetDNS(data.bibId, data.dns!);
-};
-
-const setDNF: Handler<RunnerAthleteDB> = (_, data) => {
-  return dbStatus.SetDNF(data.bibId, data.timeOut, data.dnf!, data.dnfType!);
+const setDrop: Handler<RunnerAthleteDB> = (_, data) => {
+  return dbStatus.SetDrop(data.bibId, data.timeOut, data.dropped!, data.dropReason!);
 };
 
 export const initStatusHandlers = () => {
-  ipcMain.handle("set-dns", setDNS);
-  ipcMain.handle("set-dnf", setDNF);
+  ipcMain.handle("set-drop", setDrop);
 };

--- a/src/main/ipc/status-ipc.ts
+++ b/src/main/ipc/status-ipc.ts
@@ -1,10 +1,16 @@
 import { ipcMain } from "electron";
+import { DropReason } from "$shared/enums";
 import { RunnerAthleteDB } from "$shared/models";
 import * as dbStatus from "../database/status-db";
 import { Handler } from "../types";
 
 const setDrop: Handler<RunnerAthleteDB> = (_, data) => {
-  return dbStatus.SetDrop(data.bibId, data.timeOut, data.dropped!, data.dropReason!);
+  const hasValidDropReason = Object.values(DropReason).includes(data.dropReason as DropReason);
+  const dropped =
+    data.dropped === true && hasValidDropReason && data.dropReason !== DropReason.None;
+  const dropReason = dropped ? (data.dropReason as DropReason) : DropReason.None;
+
+  return dbStatus.SetDrop(data.bibId, data.timeOut, dropped, dropReason);
 };
 
 export const initStatusHandlers = () => {

--- a/src/main/lib/file-dialogs.ts
+++ b/src/main/lib/file-dialogs.ts
@@ -51,12 +51,8 @@ export const loadRunnersFromCSV = (): Promise<string[]> => {
   return loadFromCSV("Select a runners file");
 };
 
-export const loadDNSFromCSV = (): Promise<string[]> => {
-  return loadFromCSV("Select a DNS file");
-};
-
-export const loadDNFFromCSV = (): Promise<string[]> => {
-  return loadFromCSV("Select a DNF file");
+export const loadDropsFromCSV = (): Promise<string[]> => {
+  return loadFromCSV("Select a Drops file");
 };
 
 export const loadFromCSV = async (title: string): Promise<string[]> => {
@@ -109,7 +105,7 @@ export const saveRunnersToCSV = async (): Promise<string> => {
   return result.filePath as string;
 };
 
-export const saveDNSRunnersToCSV = async (): Promise<string> => {
+export const saveDropsToCSV = async (): Promise<string> => {
   const stationId = appStore.get("station.id") as number;
   const formattedStationId = stationId.toLocaleString("en-US", {
     minimumIntegerDigits: 2,
@@ -117,36 +113,8 @@ export const saveDNSRunnersToCSV = async (): Promise<string> => {
   });
 
   const dialogConfig = {
-    title: "Specify a DNS export file",
-    defaultPath: path.join(AppPaths.userRoot, `Aid${formattedStationId}-dns`),
-    filters: [
-      { name: "Comma-Separated Values", extensions: ["csv"] },
-      { name: "All Files", extensions: ["*"] }
-    ]
-  };
-
-  const result = await openFileDialog("showSaveDialog", dialogConfig)
-    .then((result) => {
-      result.canceled ? console.log(result.canceled) : console.log(result.filePaths);
-      return result;
-    })
-    .catch((err) => {
-      console.log(err);
-    });
-
-  return result.filePath as string;
-};
-
-export const saveDNFRunnersToCSV = async (): Promise<string> => {
-  const stationId = appStore.get("station.id") as number;
-  const formattedStationId = stationId.toLocaleString("en-US", {
-    minimumIntegerDigits: 2,
-    useGrouping: false
-  });
-
-  const dialogConfig = {
-    title: "Specify a DNF export file",
-    defaultPath: path.join(AppPaths.userRoot, `Aid${formattedStationId}-dnf`),
+    title: "Specify a Drops export file",
+    defaultPath: path.join(AppPaths.userRoot, `Aid${formattedStationId}-drops`),
     filters: [
       { name: "Comma-Separated Values", extensions: ["csv"] },
       { name: "All Files", extensions: ["*"] }

--- a/src/main/lib/stat-engine.ts
+++ b/src/main/lib/stat-engine.ts
@@ -37,15 +37,17 @@ export function initStatEngine() {
 
   stats.addStat("registeredAthletes", () => dbAthlete.GetTotalAthletes());
   stats.addStat("totalRunners", () => dbRunners.GetTotalRunners());
-  stats.addStat("totalDNS", () => dbStatus.GetTotalDNS());
-  stats.addStat("previousDNF", () => dbStatus.GetPreviousDNF());
+  stats.addStat("totalDidNotStart", () => dbStatus.GetTotalDidNotStart());
+  stats.addStat("previousDrops", () => dbStatus.GetPreviousDropped());
   stats.addStat("pendingArrivals", (input) => {
     if (
       input.registeredAthletes != invalidResult ||
-      input.totalDNS != invalidResult ||
+      input.totalDidNotStart != invalidResult ||
       input.totalRunners != invalidResult
     ) {
-      return input.registeredAthletes - input.totalDNS - input.previousDNF - input.totalRunners;
+      return (
+        input.registeredAthletes - input.totalDidNotStart - input.previousDrops - input.totalRunners
+      );
     } else {
       return invalidResult;
     }
@@ -53,11 +55,11 @@ export function initStatEngine() {
   stats.addStat("inStation", () => dbRunners.GetRunnersInStation());
   stats.addStat("throughStation", () => dbRunners.GetRunnersOutStation());
   stats.addStat("finishedRace", (input) => input.defaultValue);
-  stats.addStat("stationDNF", () => dbStatus.GetStationDNF());
-  stats.addStat("totalDNF", () => dbStatus.GetTotalDNF());
+  stats.addStat("stationDrops", () => dbStatus.GetStationDropped());
+  stats.addStat("totalDrops", () => dbStatus.GetTotalDropped());
 
   stats.addStat("warnings", () => invalidResult);
-  stats.addStat("inStationDNS", () => dbRunners.GetDNSRunnersInStation());
+  stats.addStat("inStationDidNotStart", () => dbRunners.GetDidNotStartRunnersInStation());
   stats.addStat("unknownAthletes", () => dbRunners.GetUnknownRunners());
 
   stats.addStat("errors", () => invalidResult);

--- a/src/renderer/src/assets/documents/get-started.md
+++ b/src/renderer/src/assets/documents/get-started.md
@@ -18,9 +18,8 @@
 2. Load the Stations file
    1. Select Station location and set operator call sign
 3. Load the Athletes file
-4. Load the Did Not Start (DNS) File
-5. Load the most recent Did Not Finish (DNF) file
-6. Go to stats screen and begin logging athletes
+4. Load the Drops file (athletes known to have Not Started or Dropped from the race)
+5. Go to stats screen and begin logging athletes
 
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
@@ -64,7 +63,7 @@ A Filter control for any column can be opened by clicking the Filter icon (three
 
 To edit a timing record, click on the icon at the far-right side of the record row.
 
-The Edit pane allows modification or deletion of a timing record. The In and Out times, DNF and DNS status, and any notes that have been entered will be displayed. Changes to these fields must be applied to take effect, or cancelled to return to the Stats page.
+The Edit pane allows modification or deletion of a timing record. The In and Out times, Drop Reason, and any notes that have been entered will be displayed. Changes to these fields must be applied to take effect, or cancelled to return to the Stats page.
 
 If the Bib# can be matched with known athlete, the athlete's name will be displayed. The button above the name will jump to that athlete in the Roster page. A timing record for an unknown athlete is considered a warning condition, as all athletes should be known and checked in at the Start of the event, and included in the Athletes file. For a timing record not matched to athlete, limited changes can be performed, resolve the Bib# to a known athlete to modify all values.
 
@@ -126,7 +125,7 @@ _10-key entry is recommended for all stations, for laptops without, use a USB 10
 </div>
 This page provides the list of all athletes and enable the operator to search for an athlete using different search keys, such as, name, bib number, city, start time, Station TimeIn, Station TimeOut and note entries.
 
-The Status column helps station operators determine which athletes are pertinent to the station. Valid filter options for the Status column are: `Incoming, DNS, In, Out, Medical, Timeout, Withdrew`
+The Status column helps station operators determine which athletes are pertinent to the station. Valid filter options for the Status column are: `Incoming, DNS (Not Started), In, Out, Medical, Timeout, Withdrew`
 
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
@@ -187,7 +186,7 @@ Timing record indicators show the current delivery state:
 | OpenSplitTime | <img src="./img/status/upload-failed.svg" alt="Red solid circle" width="16"> | Upload failed |
 
 - **Export Incremental CSV File**
-  This function exports a `.csv` file of the station entries containing unsent or edited records, contains BibID, TimeIn, TimeOut, DNF/DNS status and any notes made by the operator. The exported file will be automatically named and incremented. e.g. `Aid05Times_04i.csv, Aid05Times_05i.csv, and Aid05Times_06i.csv`.
+  This function exports a `.csv` file of the station entries containing unsent or edited records, contains BibID, TimeIn, TimeOut, Drop Reason and any notes made by the operator. The exported file will be automatically named and incremented. e.g. `Aid05Times_04i.csv, Aid05Times_05i.csv, and Aid05Times_06i.csv`.
 
   Sending recent time records in smaller batches allows for much smaller files being routinely sent to race leadership to import to the race timing site, whether by packet radio or internet. This keeps timing data updated timely for athlete support crews and other situation in an event. Depending on the rate of athletes arriving and departing a station, sending an incremental file _every 30 minutes at a minimim_ is recommended, more often if possible.
 
@@ -196,15 +195,12 @@ Timing record indicators show the current delivery state:
   <span style="color:orange">**NOTE:** All Incremental files must be transmitted to the race leadership as each file only contains a portion of the overall station data.</span>
 
 - **Export Full CSV File**
-  This function exports a full `.csv` file of **all time records** containing TimeIn, TimeOut, DNF/DNS status and any notes made by the station operators.
+  This function exports a full `.csv` file of **all time records** containing TimeIn, TimeOut, Drop Reason and any notes made by the station operators.
 
 This file is useful as a final station report.
 
-- **Export DNS File**
-  This function exports a `.csv` file with all DNS entries that have occurred at the current station. This is unlikely to be used at any station other than the Start Line.
-
-- **Export DNF File**
-  This function exports a `.csv` file with all DNF entries that have occurred up the current station. This file is not normally needed to be sent to race organizers but can be an efficient way of sending the current station's DNF list to another station.
+- **Export Drops File**
+  This function exports a `.csv` file with all Drop entries (Not Started, Withdrew, Timeout, Medical, Unknown) that have occurred at or before the current station. This file is not normally needed to be sent to race organizers but can be an efficient way of sending the current station's Drops list to another station.
 
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
@@ -259,14 +255,12 @@ The following is a description of each button's function. Each of these will ope
   This loads a `JSON` file containing each of the stations and their detailed information to allow ease of selection while setting up this application. A typical filename will be `eventname-YYYY-stations.json`.
 - **Load Athletes File**
   This function loads a `.csv` file, supplied by race organizers, containing all athletes registered or checked in for the event, whether they are known to have started _or not_.
-- **Load DNS File**
-  This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** the race.
-- **Load DNF File**
-  This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not finished** the race.
+- **Load Drops File**
+  This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** or **dropped from** the race (Withdrew, Timeout, Medical, Unknown).
 
-  As an event proceeds more DNF athletes will be recorded and new DNF files will be supplied to stations.
+  As an event proceeds more Drops will be recorded and new Drops files will be supplied to stations.
 
-  Importing new DNF files will update all athletes recorded and DNF earlier in the race, DNFs past the current station are ignored. This provides insight of which athletes are still expected into the current station.
+  Importing new Drops files will update all athletes recorded as dropped at or before the current station; drops past the current station are ignored. This provides insight of which athletes are still expected into the current station.
 
 #### RFID Configuration
 
@@ -299,8 +293,7 @@ The following is a description of each button's function. Each of these will ope
 
 1. Load the Stations file.
 1. Load the Athletes file.
-1. Load the DNS file.
-1. Load the most recent DNF file.
+1. Load the Drops file.
 1. Import a Full Export file using "Recover Data From CSV File".
 
 ### Local Database

--- a/src/renderer/src/components/StatusTag.tsx
+++ b/src/renderer/src/components/StatusTag.tsx
@@ -1,21 +1,21 @@
-import { AthleteProgress, DNFType } from "$shared/enums";
+import { AthleteProgress, DropReason } from "$shared/enums";
 import { Tag, TagColor } from "./Tag";
 
 interface Props {
-  dnfType?: DNFType;
-  dns?: boolean;
+  dropReason?: DropReason;
   AthleteProgress?: AthleteProgress;
   duplicate?: boolean;
 }
 
 type TagInfo = { color: TagColor; text: string };
 
-const dnfTypeMap: Record<DNFType, TagInfo | null> = {
-  [DNFType.Withdrew]: { color: "turquoise", text: "Withdrew" },
-  [DNFType.Timeout]: { color: "purple", text: "Timeout" },
-  [DNFType.Medical]: { color: "red", text: "Medical" },
-  [DNFType.Unknown]: { color: "gray", text: "Unknown" },
-  [DNFType.None]: null
+const dropReasonMap: Record<DropReason, TagInfo | null> = {
+  [DropReason.DidNotStart]: { color: "blue", text: "DNS" },
+  [DropReason.Withdrew]: { color: "turquoise", text: "Withdrew" },
+  [DropReason.Timeout]: { color: "purple", text: "Timeout" },
+  [DropReason.Medical]: { color: "red", text: "Medical" },
+  [DropReason.Unknown]: { color: "gray", text: "Unknown" },
+  [DropReason.None]: null
 };
 
 const AthleteProgressMap: Record<AthleteProgress, TagInfo | null> = {
@@ -27,10 +27,8 @@ const AthleteProgressMap: Record<AthleteProgress, TagInfo | null> = {
 function getTagInfo(props: Props): TagInfo | null {
   if (props.duplicate) {
     return { color: "yellow", text: "Duplicate" };
-  } else if (props.dnfType && props.dnfType != DNFType.None) {
-    return dnfTypeMap[props.dnfType];
-  } else if (props.dns) {
-    return { color: "blue", text: "DNS" };
+  } else if (props.dropReason && props.dropReason != DropReason.None) {
+    return dropReasonMap[props.dropReason];
   } else if (props.AthleteProgress) {
     return AthleteProgressMap[props.AthleteProgress];
   } else {

--- a/src/renderer/src/features/ExportPage/ExportPage.tsx
+++ b/src/renderer/src/features/ExportPage/ExportPage.tsx
@@ -10,12 +10,8 @@ export function ExportPage() {
     preToast: "Exporting to CSV file"
   });
 
-  const createDNSCSVFile = useBasicIpcCall("export-dns-file", {
-    preToast: "Exporting DNS to CSV file"
-  });
-
-  const createDNFCSVFile = useBasicIpcCall("export-dnf-file", {
-    preToast: "Exporting DNF to CSV file"
+  const createDropsCSVFile = useBasicIpcCall("export-drops-file", {
+    preToast: "Exporting Drops to CSV file"
   });
 
   const openExportDirectory = useBasicIpcCall("open-export-dir", {
@@ -31,11 +27,8 @@ export function ExportPage() {
         <Button color="primary" size="wide" onClick={() => createRunnerCSVFile.mutate()}>
           Export Full CSV File
         </Button>
-        <Button color="primary" size="wide" onClick={() => createDNSCSVFile.mutate()}>
-          Export DNS CSV File
-        </Button>
-        <Button color="primary" size="wide" onClick={() => createDNFCSVFile.mutate()}>
-          Export DNF CSV File
+        <Button color="primary" size="wide" onClick={() => createDropsCSVFile.mutate()}>
+          Export Drops CSV File
         </Button>
       </VerticalButtonGroup>
       <VerticalButtonGroup label="Export Files" className="align-text-top mb-32">

--- a/src/renderer/src/features/RosterPage/RosterPage.tsx
+++ b/src/renderer/src/features/RosterPage/RosterPage.tsx
@@ -30,7 +30,7 @@ export function RosterPage() {
         <StatusTag dropReason={dropReason} AthleteProgress={progress} />
       ),
       valueFn: (athlete) =>
-        `${athlete.dropReason! === DropReason.None ? "" : athlete.dropReason}
+        `${athlete.dropReason! === DropReason.None ? "" : athlete.dropReason! === DropReason.DidNotStart ? "DNS" : athlete.dropReason}
          ${athlete.progress! === AthleteProgress.Incoming ? "Incoming" : ""}
          ${athlete.progress! === AthleteProgress.Present ? "In" : ""}
          ${athlete.progress! === AthleteProgress.Outgoing && athlete.dropReason! !== DropReason.DidNotStart ? "Out" : ""}

--- a/src/renderer/src/features/RosterPage/RosterPage.tsx
+++ b/src/renderer/src/features/RosterPage/RosterPage.tsx
@@ -3,7 +3,7 @@
 import { getRouteApi, useNavigate } from "@tanstack/react-router";
 import { StatusTag } from "~/components/StatusTag";
 import { useAthletes } from "~/hooks/data/useAthletes";
-import { AthleteProgress, DNFType } from "$shared/enums";
+import { AthleteProgress, DropReason } from "$shared/enums";
 import { AthleteStatusDB } from "$shared/models";
 import { EmergencyContact } from "./EmergencyContact";
 import { ColumnDef, DataGrid } from "../DataGrid";
@@ -24,17 +24,17 @@ export function RosterPage() {
       align: "right"
     },
     {
-      field: "dnfType",
+      field: "dropReason",
       name: "Status",
-      render: (dnfType, { dns, progress }) => (
-        <StatusTag dnfType={dnfType} dns={dns} AthleteProgress={progress} />
+      render: (dropReason, { progress }) => (
+        <StatusTag dropReason={dropReason} AthleteProgress={progress} />
       ),
       valueFn: (athlete) =>
-        `${athlete.dnfType! === DNFType.None ? "" : athlete.dnfType + "dnf"}
+        `${athlete.dropReason! === DropReason.None ? "" : athlete.dropReason}
          ${athlete.progress! === AthleteProgress.Incoming ? "Incoming" : ""}
          ${athlete.progress! === AthleteProgress.Present ? "In" : ""}
-         ${athlete.progress! === AthleteProgress.Outgoing && !athlete.dns! ? "Out" : ""}
-         ${athlete.dns! ? "DNS" : ""}`,
+         ${athlete.progress! === AthleteProgress.Outgoing && athlete.dropReason! !== DropReason.DidNotStart ? "Out" : ""}
+         ${athlete.dropReason! === DropReason.DidNotStart ? "Not Started" : ""}`,
       width: "9%"
     },
     {

--- a/src/renderer/src/features/RunnerEntry/EditRunner.tsx
+++ b/src/renderer/src/features/RunnerEntry/EditRunner.tsx
@@ -23,7 +23,7 @@ import {
   usePushOpenSplitTimeRecord
 } from "~/hooks/data/useTiming";
 import { useId } from "~/hooks/useId";
-import { DNFType, RecordStatus } from "$shared/enums";
+import { DropReason, RecordStatus } from "$shared/enums";
 import { useSelectRunnerForm } from "./hooks/useSelectRunnerForm";
 import { useToasts } from "../Toasts/useToasts";
 
@@ -71,7 +71,7 @@ export function EditRunner(props: Props) {
         bibId: updatedBibId,
         status:
           isIntegerBib && data.status === RecordStatus.Duplicate ? RecordStatus.OK : data.status,
-        dnf: (data.dnfType as DNFType) !== DNFType.None
+        dropped: (data.dropReason as DropReason) !== DropReason.None
       };
 
       form.reset({ ...formattedData });
@@ -251,24 +251,19 @@ export function EditRunner(props: Props) {
                     selectedRunner.state.status === RecordStatus.Duplicate || athlete === null
                   }
                   onChange={(value) => {
-                    form.setValue("dnfType", value ? (value as DNFType) : DNFType.None);
+                    form.setValue("dropReason", value ? (value as DropReason) : DropReason.None);
                   }}
-                  className="w-1/2"
-                  label="DNF"
-                  value={form.watch("dnfType")}
-                  options={["medical", "withdrew", "timeout", "none"]}
-                  placeholder="DNF"
-                />
-                <Select
-                  disabled={
-                    selectedRunner.state.status === RecordStatus.Duplicate || athlete === null
-                  }
-                  onChange={(value) => form.setValue("dns", value === "dns")}
-                  className="w-1/2"
-                  label="DNS"
-                  value={form.watch("dns") ? "dns" : "none"}
-                  options={["dns", "none"]}
-                  placeholder="DNF"
+                  className="w-full"
+                  label="Drop Reason"
+                  value={form.watch("dropReason")}
+                  options={[
+                    { name: "Did Not Start", value: DropReason.DidNotStart },
+                    { name: "Medical", value: DropReason.Medical },
+                    { name: "Withdrew", value: DropReason.Withdrew },
+                    { name: "Timeout", value: DropReason.Timeout },
+                    { name: "None", value: DropReason.None }
+                  ]}
+                  placeholder="Drop Reason"
                 />
               </Stack>
               <TextInput

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -3,7 +3,7 @@ import { StatusTag } from "~/components/StatusTag";
 import { ColumnDef, DataGrid } from "~/features/DataGrid";
 import { RowStatus } from "~/features/DataGrid/types";
 import { formatDate } from "~/lib/datetimes";
-import { DNFType, RecordStatus } from "$shared/enums";
+import { DropReason, RecordStatus } from "$shared/enums";
 import { EditRunner } from "./EditRunner";
 import { InTimeCell } from "./InTimeCell";
 import { RunnerFormStats } from "./RunnerFormStats";
@@ -43,15 +43,13 @@ export function RunnerEntry() {
       width: "160px"
     },
     {
-      field: "dnfType",
+      field: "dropReason",
       name: "Status",
       truncate: false,
-      render: (dnfType, { dns, status }) => (
-        <StatusTag dnfType={dnfType} dns={dns} duplicate={status === RecordStatus.Duplicate} />
+      render: (dropReason, { status }) => (
+        <StatusTag dropReason={dropReason} duplicate={status === RecordStatus.Duplicate} />
       ),
-      valueFn: (data) =>
-        `${data.dnfType! === DNFType.None ? "" : data.dnfType + "dnf"},
-         ${data.dns! ? "DNS" : ""}`,
+      valueFn: (data) => `${data.dropReason! === DropReason.None ? "" : data.dropReason}`,
       width: "118px"
     },
     {

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -49,7 +49,12 @@ export function RunnerEntry() {
       render: (dropReason, { status }) => (
         <StatusTag dropReason={dropReason} duplicate={status === RecordStatus.Duplicate} />
       ),
-      valueFn: (data) => `${data.dropReason! === DropReason.None ? "" : data.dropReason}`,
+      valueFn: (data) =>
+        data.dropReason! === DropReason.None
+          ? ""
+          : data.dropReason! === DropReason.DidNotStart
+            ? "DNS"
+            : data.dropReason,
       width: "118px"
     },
     {

--- a/src/renderer/src/features/RunnerEntry/Stats.tsx
+++ b/src/renderer/src/features/RunnerEntry/Stats.tsx
@@ -26,20 +26,20 @@ function useStats() {
       value: formatStat(statsData?.throughStation)
     },
     {
-      id: "Total DNS",
-      value: formatStat(statsData?.totalDNS)
+      id: "Not Started",
+      value: formatStat(statsData?.totalDidNotStart)
     },
     {
-      id: "Prior DNF",
-      value: formatStat(statsData?.previousDNF)
+      id: "Prior Drops",
+      value: formatStat(statsData?.previousDrops)
     },
     {
-      id: "Station DNF",
-      value: formatStat(statsData?.stationDNF)
+      id: "Station Drops",
+      value: formatStat(statsData?.stationDrops)
     },
     {
-      id: "Total DNF",
-      value: formatStat(statsData?.totalDNF)
+      id: "Total Drops",
+      value: formatStat(statsData?.totalDrops)
     },
     {
       id: " ",
@@ -50,8 +50,8 @@ function useStats() {
       value: ""
     },
     {
-      id: "- In Station DNS",
-      value: formatStat(statsData?.inStationDNS)
+      id: "- DNS In Station",
+      value: formatStat(statsData?.inStationDidNotStart)
     },
     {
       id: "- Unknown Bibs",

--- a/src/renderer/src/features/SettingsPage/SettingsPage.tsx
+++ b/src/renderer/src/features/SettingsPage/SettingsPage.tsx
@@ -22,11 +22,8 @@ export function SettingsPage() {
             <Button size="wide" onClick={() => settingsMutations.importAthletesFile.mutate()}>
               Load Athletes File
             </Button>
-            <Button size="wide" onClick={() => settingsMutations.importDNSFile.mutate()}>
-              Load DNS File
-            </Button>
-            <Button size="wide" onClick={() => settingsMutations.importDNFFile.mutate()}>
-              Load DNF File
+            <Button size="wide" onClick={() => settingsMutations.importDropsFile.mutate()}>
+              Load Drops File
             </Button>
           </VerticalButtonGroup>
 

--- a/src/renderer/src/features/SettingsPage/hooks/useSettingsMutations.tsx
+++ b/src/renderer/src/features/SettingsPage/hooks/useSettingsMutations.tsx
@@ -14,12 +14,8 @@ export function useSettingsMutations() {
     preToast: "Loading Stations file"
   });
 
-  const importDNSFile = useBasicIpcCall("load-dns-file", {
-    preToast: "Loading DNS file"
-  });
-
-  const importDNFFile = useBasicIpcCall("load-dnf-file", {
-    preToast: "Loading DNF file"
+  const importDropsFile = useBasicIpcCall("load-drops-file", {
+    preToast: "Loading Drops file"
   });
 
   const importRunnerCSVFile = useBasicIpcCall("import-runners-file", {
@@ -61,8 +57,7 @@ export function useSettingsMutations() {
     disconnectRfid,
     importAthletesFile,
     importStationsFile,
-    importDNSFile,
-    importDNFFile,
+    importDropsFile,
     importRunnerCSVFile,
     reinitializeDatabase
   };

--- a/src/renderer/src/hooks/data/useRunnerData.tsx
+++ b/src/renderer/src/hooks/data/useRunnerData.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { DNFType, RecordStatus } from "$shared/enums";
+import { DropReason, RecordStatus } from "$shared/enums";
 import { RunnerAthleteDB } from "$shared/models";
 import { DatabaseResponse } from "$shared/types";
 import { useHandleStatusToasts } from "../useHandleStatusToasts";
@@ -18,9 +18,8 @@ export interface RunnerEx extends Runner {
   sequence: number;
   sent: boolean;
   openSplitTimeAuthenticated: boolean;
-  dns: boolean;
-  dnf: boolean;
-  dnfType: DNFType;
+  dropped: boolean;
+  dropReason: DropReason;
   status: RecordStatus;
   openSplitTimePushStatus?: "success" | "pending" | "error";
   openSplitTimePushError?: string;
@@ -50,7 +49,7 @@ export function useRunnerData() {
     queryKey: ["runners-table"],
     queryFn: async (): Promise<RunnerEx[]> => {
       const [response, authResult] = await Promise.all([
-        ipcRenderer.invoke("get-runners-table", { includeDNF: true }),
+        ipcRenderer.invoke("get-runners-table", { includeDrops: true }),
         ipcRenderer.invoke("opensplittime-get-auth-status")
       ]);
       const [data, status, message]: DatabaseResponse<RunnerAthleteDB[]> = response;
@@ -69,9 +68,8 @@ export function useRunnerData() {
         note: runner.note,
         sent: runner.sent,
         openSplitTimeAuthenticated: authenticated,
-        dns: runner.dns ?? false,
-        dnf: runner.dnf ?? false,
-        dnfType: runner.dnfType ?? DNFType.None,
+        dropped: runner.dropped ?? false,
+        dropReason: runner.dropReason ?? DropReason.None,
         status: runner.status ?? RecordStatus.OK,
         openSplitTimePushStatus: runner.openSplitTimePushStatus,
         openSplitTimePushError: runner.openSplitTimePushError

--- a/src/renderer/src/hooks/data/useStatsData.tsx
+++ b/src/renderer/src/hooks/data/useStatsData.tsx
@@ -8,12 +8,12 @@ export interface Stats {
   inStation: number;
   throughStation: number;
   finishedRace: number;
-  totalDNS: number;
-  previousDNF: number;
-  stationDNF: number;
-  totalDNF: number;
+  totalDidNotStart: number;
+  previousDrops: number;
+  stationDrops: number;
+  totalDrops: number;
   warnings: number;
-  inStationDNS: number;
+  inStationDidNotStart: number;
   unknownAthletes: number;
   errors: number;
   duplicates: number;

--- a/src/renderer/src/hooks/data/useStatus.tsx
+++ b/src/renderer/src/hooks/data/useStatus.tsx
@@ -33,10 +33,7 @@ export function useSetAthleteProgress() {
 
       console.log("updatedData", updatedData);
 
-      return Promise.all([
-        ipcRenderer.invoke("set-dnf", updatedData),
-        ipcRenderer.invoke("set-dns", updatedData)
-      ]);
+      return ipcRenderer.invoke("set-drop", updatedData);
     },
 
     onSuccess: () => {

--- a/src/renderer/src/lib/primeReactTheme/dropdown.ts
+++ b/src/renderer/src/lib/primeReactTheme/dropdown.ts
@@ -30,9 +30,8 @@ export const DropdownPT: DropdownPassThroughOptions = {
   }),
   wrapper: (params) => {
     return {
-      style: { scrollbarWidth: "none" },
       className: classNames(
-        "overflow-auto max-h-[200px] bg-surface-secondary",
+        "overflow-y-auto max-h-[280px] bg-surface-secondary",
         "shadow-lg text-on-surface",
         { "rounded-br-lg rounded-bl-lg": params?.props.filter },
         { "rounded-lg": !params?.props.filter }

--- a/src/shared/enums.ts
+++ b/src/shared/enums.ts
@@ -14,8 +14,9 @@ export enum DatabaseStatus {
   Success
 }
 
-export enum DNFType {
+export enum DropReason {
   None = "none",
+  DidNotStart = "did-not-start",
   Withdrew = "withdrew",
   Timeout = "timeout",
   Medical = "medical",
@@ -48,4 +49,3 @@ export enum DeviceStatus {
   Disconnecting,
   Error
 }
-

--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -1,4 +1,4 @@
-import { AthleteProgress, DNFType, DeviceStatus, EntryMode, RecordType } from "./enums";
+import { AthleteProgress, DeviceStatus, DropReason, EntryMode, RecordType } from "./enums";
 
 /**
  * Custom models (types) for ultra-tracker
@@ -24,9 +24,9 @@ export interface RunnerCSV {
   timeOut: string;
   note: string;
   sent: number;
-  dnfType: string;
-  dnfStation: string;
-  dnfDateTime: string;
+  dropReason: string;
+  dropStation: string;
+  dropDateTime: string;
 }
 
 export interface Runner {
@@ -53,11 +53,10 @@ export type AthleteDB = {
 
 export type StatusDB = {
   bibId: number;
-  dns: boolean | undefined;
-  dnf: boolean | undefined;
-  dnfType: DNFType | undefined;
-  dnfStation: string | undefined;
-  dnfDateTime: Date | null;
+  dropped: boolean | undefined;
+  dropReason: DropReason | undefined;
+  dropStation: string | undefined;
+  dropDateTime: Date | null;
   note: string | undefined;
   progress: AthleteProgress | undefined;
 };
@@ -114,18 +113,11 @@ export type Operator = {
   active: boolean;
 };
 
-export type DNSRecord = {
+export type DropRecord = {
   stationId: string;
   bibId: number;
-  dnsDateTime: string;
-  note: string;
-};
-
-export type DNFRecord = {
-  stationIdentifier: string;
-  bibId: number;
-  dnfType: string;
-  dnfDateTime: string;
+  dropReason: string;
+  dropDateTime: string;
   note: string;
 };
 
@@ -141,10 +133,10 @@ export type EventLogRec = {
   verbose: boolean | undefined;
 };
 
-export type RunnerAthleteDB = RunnerDB & Pick<StatusDB, "dnf" | "dnfType" | "dns">;
+export type RunnerAthleteDB = RunnerDB & Pick<StatusDB, "dropped" | "dropReason">;
 
 export type AthleteStatusDB = AthleteDB &
-  Pick<StatusDB, "dns" | "dnf" | "dnfType" | "note" | "progress">;
+  Pick<StatusDB, "dropped" | "dropReason" | "note" | "progress">;
 
 export type RfidSettings = {
   type: string;


### PR DESCRIPTION
## Summary
Unify DNS/DNF terminology and state handling to DropReason across the application. This updates storage, IPC, import/export, operator UI, and help content for the revised domain model.

## Changes
- **Domain model**: replace DNS/DNF fields and statuses with Drop/Drop Reason shared types and database schema support
- **Operations**: update migrations, status handling, IPC, CSV import/export, and statistics for drops
- **Operator UI**: revise roster, runner entry, settings, status tags, documentation, and dropdown scrolling behavior

## Testing
- git diff --check HEAD^ HEAD - passes clean