### PR TITLE
feat: add font scaling to data grids

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { join } from "path";
 import { electronApp, is, optimizer } from "@electron-toolkit/utils";
-import { BrowserWindow, Event, app, dialog, powerMonitor, shell } from "electron";
+import { BrowserWindow, Event, Menu, app, dialog, powerMonitor, shell } from "electron";
 import iconLinux from "$resources/iconLinux.png?asset";
 import { DisconnectRFIDReader, RecoverRFIDReader } from "./api/rfid-processor";
 import { createDatabaseConnection } from "./database/connect-db";
@@ -12,6 +12,30 @@ import { LogLevel, initialize, shutdown, uberLog } from "./lib/logger";
 import { initStatEngine } from "./lib/stat-engine";
 
 let mainWindow: BrowserWindow | null = null;
+
+// Drop the default zoom accelerators (they conflict with the app's own grid font scale shortcuts)
+// while keeping reload/devtools/fullscreen available.
+function setApplicationMenu(): void {
+  const isMac = process.platform === "darwin";
+
+  Menu.setApplicationMenu(
+    Menu.buildFromTemplate([
+      ...(isMac ? [{ role: "appMenu" as const }] : []),
+      { role: "editMenu" },
+      {
+        label: "View",
+        submenu: [
+          { role: "reload" },
+          { role: "forceReload" },
+          { role: "toggleDevTools" },
+          { type: "separator" },
+          { role: "togglefullscreen" }
+        ]
+      },
+      { role: "windowMenu" }
+    ])
+  );
+}
 
 function createWindow(): BrowserWindow {
   mainWindow = new BrowserWindow({
@@ -85,6 +109,8 @@ async function initializeApp(): Promise<void> {
   uberLog(LogLevel.info, "startup", "Application execution path:" + app.getAppPath(), false);
 
   electronApp.setAppUserModelId("com.electron");
+
+  setApplicationMenu();
 
   createWindow();
 

--- a/src/main/lib/store.ts
+++ b/src/main/lib/store.ts
@@ -43,6 +43,9 @@ const defaults = {
   openSplitTime: {
     email: "",
     encryptedPassword: ""
+  },
+  display: {
+    gridFontScale: 1
   }
 };
 
@@ -116,6 +119,12 @@ export const appStore = new Store({
       properties: {
         email: { type: "string", default: "" },
         encryptedPassword: { type: "string", default: "" }
+      }
+    },
+    display: {
+      type: "object",
+      properties: {
+        gridFontScale: { type: "number", default: 1, minimum: 0.8, maximum: 1.6 }
       }
     }
     //required: ["id", "identifier", "name", "entryMode", "operators"]

--- a/src/renderer/src/features/Footer/Footer.tsx
+++ b/src/renderer/src/features/Footer/Footer.tsx
@@ -50,9 +50,9 @@ export function Footer() {
     <Stack
       justify="between"
       align="center"
-      className="py-6 pl-4 m-4 text-lg bg-component font-display"
+      className="py-[24px] pl-[16px] m-[16px] text-[18px] bg-component font-display"
     >
-      <Stack direction="row" align="center" className="gap-4">
+      <Stack direction="row" align="center" className="gap-[16px]">
         <Stack direction="col">
           <p className="text-on-component">
             <span className="font-bold">Aid Station</span> - {title}
@@ -64,16 +64,16 @@ export function Footer() {
 
         <Stack
           direction="col"
-          className="gap-2 px-4 py-2 text-sm border rounded-md border-component-strong bg-surface-tertiary"
+          className="gap-[8px] px-[16px] py-[8px] text-[14px] border rounded-md border-component-strong bg-surface-tertiary"
         >
-          <Stack id={internetTooltipId} direction="row" align="center" className="gap-2">
+          <Stack id={internetTooltipId} direction="row" align="center" className="gap-[8px]">
             <span className="text-on-component">Internet:</span>
             {statusIcon(connectionStatus.checking, connectionStatus.internet)}
             <Tooltip position="top" target={`#${internetTooltipId}`}>
               {statusText(connectionStatus.checking, connectionStatus.internet)}
             </Tooltip>
           </Stack>
-          <Stack id={openSplitTimeTooltipId} direction="row" align="center" className="gap-2">
+          <Stack id={openSplitTimeTooltipId} direction="row" align="center" className="gap-[8px]">
             <span className="text-on-component">OpenSplitTime:</span>
             {statusIcon(connectionStatus.checking, connectionStatus.openSplitTime)}
             <Tooltip position="top" target={`#${openSplitTimeTooltipId}`}>

--- a/src/renderer/src/features/SettingsPage/SettingsPage.tsx
+++ b/src/renderer/src/features/SettingsPage/SettingsPage.tsx
@@ -53,7 +53,7 @@ export function SettingsPage() {
               Reset Grid Text Size
             </Button>
             <p className="w-80 text-on-surface-strong italic font-display text-sm mt-2">
-              Adjusts text size in data grids. You can also use Ctrl + / Ctrl - / Ctrl 0.
+              Adjusts text size in data grids. You can also use Ctrl/Cmd + = / - / 0.
             </p>
           </VerticalButtonGroup>
 

--- a/src/renderer/src/features/SettingsPage/SettingsPage.tsx
+++ b/src/renderer/src/features/SettingsPage/SettingsPage.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
 import { Button, ConfirmationModal, Stack, VerticalButtonGroup } from "~/components";
+import { useGridFontScale } from "~/hooks/dom/useGridFontScale";
 import { useSettingsMutations } from "./hooks/useSettingsMutations";
 import { OpenSplitTimeLogin } from "./OpenSplitTimeLogin";
 import { RfidConfiguration } from "./RfidConfiguration";
 
 export function SettingsPage() {
   const settingsMutations = useSettingsMutations();
+  const gridFontScale = useGridFontScale();
   const [resetOpen, setResetOpen] = useState(false);
   const [recreateOpen, setRecreateOpen] = useState(false);
   const [recoverOpen, setRecoverOpen] = useState(false);
@@ -35,6 +37,26 @@ export function SettingsPage() {
 
         {/* Column 3: Developer Tools + App Settings */}
         <Stack direction="col" className="w-[22rem] gap-4" align="stretch">
+          <VerticalButtonGroup label="Display">
+            <Stack align="center" className="gap-3">
+              <Button size="md" onClick={gridFontScale.decrease}>
+                A-
+              </Button>
+              <span className="w-16 text-center font-display text-on-surface-strong">
+                {Math.round(gridFontScale.scale * 100)}%
+              </span>
+              <Button size="md" onClick={gridFontScale.increase}>
+                A+
+              </Button>
+            </Stack>
+            <Button size="wide" onClick={gridFontScale.reset}>
+              Reset Grid Text Size
+            </Button>
+            <p className="w-80 text-on-surface-strong italic font-display text-sm mt-2">
+              Adjusts text size in data grids. You can also use Ctrl + / Ctrl - / Ctrl 0.
+            </p>
+          </VerticalButtonGroup>
+
           <VerticalButtonGroup label="Developer Tools" className="border-2 border-danger/30">
             <Stack direction="col" className="gap-2">
               <p className="w-80 text-on-surface-strong italic font-display text-sm font-bold mt-2 mb-4">

--- a/src/renderer/src/features/Sidebar/Sidebar.tsx
+++ b/src/renderer/src/features/Sidebar/Sidebar.tsx
@@ -14,11 +14,11 @@ import { SidebarLink } from "./SidebarLink";
 import { ThemeToggle } from "./ThemeToggle";
 
 const SidebarElement = classed.div({
-  base: "overflow-hidden fixed z-50 pt-8 pb-2 h-full duration-100 ease-in-out bg-surface-secondary transition-width group",
+  base: "overflow-hidden fixed z-50 pt-[32px] pb-[8px] h-full duration-100 ease-in-out bg-surface-secondary transition-width group",
   variants: {
     open: {
-      true: "w-56",
-      false: "w-16"
+      true: "w-[224px]",
+      false: "w-[64px]"
     }
   }
 });

--- a/src/renderer/src/features/Sidebar/SidebarButton.tsx
+++ b/src/renderer/src/features/Sidebar/SidebarButton.tsx
@@ -15,7 +15,7 @@ export interface SidebarButtonProps extends SidebarItemProps {
 //
 const SidebarStack = classed(
   Stack,
-  "static py-2 my-0.5 ml-4 text-lg font-bold uppercase transition-all duration-100 cursor-pointer font-display *:transition-all *:duration-100 text-on-surface group/link",
+  "static py-[8px] my-[2px] ml-[16px] text-[18px] font-bold uppercase transition-all duration-100 cursor-pointer font-display *:transition-all *:duration-100 text-on-surface group/link",
   {
     variants: {
       active: {
@@ -30,7 +30,7 @@ const SidebarStack = classed(
 // Use a separate indicator rather than border to allow a smooth transition
 // of the indicator location when expanding/collapsing the sidebar
 const Indicator = classed.div({
-  base: "absolute right-0 w-1",
+  base: "absolute right-0 w-[4px]",
   variants: {
     active: {
       true: "opacity-100 bg-primary",
@@ -56,7 +56,7 @@ export function SidebarButton(props: SidebarButtonProps) {
         {
           // TODO: fix TS2769
           props.icon({
-            className: "mr-4 ml-1",
+            className: "mr-[16px] ml-[4px]",
             title: props.children,
             height: 28,
             width: 28

--- a/src/renderer/src/hooks/dom/useGridFontScale.tsx
+++ b/src/renderer/src/hooks/dom/useGridFontScale.tsx
@@ -1,0 +1,43 @@
+import { useLayoutEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useStoreValue } from "~/hooks/ipc/useStoreValue";
+import { useIpcRenderer } from "~/hooks/useIpcRenderer";
+
+export const GRID_FONT_SCALE_MIN = 0.8;
+export const GRID_FONT_SCALE_MAX = 1.6;
+export const GRID_FONT_SCALE_STEP = 0.1;
+export const GRID_FONT_SCALE_DEFAULT = 1;
+
+const STORE_KEY = "display.gridFontScale";
+const QUERY_KEY = ["store", "get", "station", STORE_KEY];
+
+function clampScale(value: number) {
+  const clamped = Math.min(GRID_FONT_SCALE_MAX, Math.max(GRID_FONT_SCALE_MIN, value));
+  return Math.round(clamped * 100) / 100;
+}
+
+// Persists to the app's settings store so it survives restarts, and scales the document's root
+// font size so every rem-based element (grid text, buttons, inputs, portaled overlays) grows
+// together, similar to browser zoom.
+export function useGridFontScale() {
+  const ipcRenderer = useIpcRenderer();
+  const queryClient = useQueryClient();
+  const { data } = useStoreValue<number>(STORE_KEY);
+  const scale = data ?? GRID_FONT_SCALE_DEFAULT;
+
+  useLayoutEffect(() => {
+    document.documentElement.style.fontSize = `${16 * scale}px`;
+  }, [scale]);
+
+  const setScale = (value: number) => {
+    const clamped = clampScale(value);
+    queryClient.setQueryData(QUERY_KEY, clamped);
+    void ipcRenderer.invoke("set-store-value", { key: STORE_KEY, value: clamped });
+  };
+
+  const increase = () => setScale(scale + GRID_FONT_SCALE_STEP);
+  const decrease = () => setScale(scale - GRID_FONT_SCALE_STEP);
+  const reset = () => setScale(GRID_FONT_SCALE_DEFAULT);
+
+  return { scale, increase, decrease, reset };
+}

--- a/src/renderer/src/hooks/dom/useGridFontScale.tsx
+++ b/src/renderer/src/hooks/dom/useGridFontScale.tsx
@@ -35,8 +35,10 @@ export function useGridFontScale() {
     void ipcRenderer.invoke("set-store-value", { key: STORE_KEY, value: clamped });
   };
 
-  const increase = () => setScale(scale + GRID_FONT_SCALE_STEP);
-  const decrease = () => setScale(scale - GRID_FONT_SCALE_STEP);
+  const increase = () =>
+    setScale((queryClient.getQueryData<number>(QUERY_KEY) ?? scale) + GRID_FONT_SCALE_STEP);
+  const decrease = () =>
+    setScale((queryClient.getQueryData<number>(QUERY_KEY) ?? scale) - GRID_FONT_SCALE_STEP);
   const reset = () => setScale(GRID_FONT_SCALE_DEFAULT);
 
   return { scale, increase, decrease, reset };

--- a/src/renderer/src/hooks/dom/useGridFontScaleShortcuts.tsx
+++ b/src/renderer/src/hooks/dom/useGridFontScaleShortcuts.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { useGridFontScale } from "./useGridFontScale";
+
+// Global Ctrl/Cmd + =/-/0 shortcuts to scale data grid text, similar to browser zoom.
+export function useGridFontScaleShortcuts() {
+  const { increase, decrease, reset } = useGridFontScale();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!(event.ctrlKey || event.metaKey)) return;
+
+      switch (event.code) {
+        case "Equal":
+        case "NumpadAdd":
+          event.preventDefault();
+          increase();
+          break;
+        case "Minus":
+        case "NumpadSubtract":
+          event.preventDefault();
+          decrease();
+          break;
+        case "Digit0":
+        case "Numpad0":
+          event.preventDefault();
+          reset();
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [increase, decrease, reset]);
+}

--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -4,13 +4,16 @@ import { Footer } from "~/features/Footer/Footer";
 import { Header } from "~/features/Header/Header";
 import { Sidebar } from "~/features/Sidebar/Sidebar";
 import { ToastProvider } from "~/features/Toasts/ToastsProvider";
+import { useGridFontScaleShortcuts } from "~/hooks/dom/useGridFontScaleShortcuts";
 
-export const Route = createRootRoute({
-  component: () => (
+function Root() {
+  useGridFontScaleShortcuts();
+
+  return (
     <BackdropProvider>
       <ToastProvider>
         <Sidebar />
-        <div className="flex overflow-hidden flex-col ml-16 w-screen">
+        <div className="flex overflow-hidden flex-col ml-[64px] w-screen">
           <Header />
           <div className="mx-4 grow max-h-[calc(100vh-260px)]">
             <Outlet />
@@ -19,5 +22,9 @@ export const Route = createRootRoute({
         </div>
       </ToastProvider>
     </BackdropProvider>
-  )
+  );
+}
+
+export const Route = createRootRoute({
+  component: Root
 });


### PR DESCRIPTION
## Summary
Closes #257. Adds a persisted, global grid font scale setting so data grid text, buttons, and text inputs scale together (similar to browser zoom), with keyboard shortcuts and a Settings page control.

## Changes
- **Main**: replace the default Electron application menu with a trimmed one that keeps Reload/Force Reload/Toggle DevTools/Fullscreen/Edit/Window but drops the default zoom accelerators, since they conflicted with the app's own font scale shortcuts.
- **Settings**: persist `display.gridFontScale` in the electron-store settings schema (default `1`, range `0.8`-`1.6`) via the existing get/set-store-value IPC.
- **Renderer**: add `useGridFontScale` and `useGridFontScaleShortcuts` hooks; wire shortcuts (Ctrl/Cmd `=`/`-`/`0`) into the root route, and scale the document root font-size so portaled overlay content (e.g. filter popups) scales too.
- **Settings page**: add a "Display" section with A-/A+ buttons, a percentage readout, and a reset button.
- **Chrome**: pin Sidebar and Footer layout classes to fixed-pixel arbitrary values so nav/status chrome is unaffected by the font scale, which is meant to affect content only.

## Testing
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec eslint` on all changed files (only pre-existing, unrelated lint errors remain)