### PR TITLE
fix: notes not saving on timing records

### DIFF
--- a/src/main/database/status-db.ts
+++ b/src/main/database/status-db.ts
@@ -413,8 +413,9 @@ export function syncNoteWithStatus(
   const statusResult = GetStatusByBib(bibId);
   let combinedNote: string = "";
 
-  if (statusResult[1] != DatabaseStatus.Success) return;
-
+  // An athlete missing from the roster has no Status row, but their timing record still needs the
+  // note, so carry on with an empty status note and skip only the Status write below.
+  const hasStatus = statusResult[1] == DatabaseStatus.Success;
   const status = statusResult[0];
   const statusNote = status?.note == undefined ? "" : status?.note;
 
@@ -439,7 +440,8 @@ export function syncNoteWithStatus(
         index
       );
     }
-    db.prepare(`UPDATE Status SET note = ? WHERE "bibId" = ?`).run(combinedNote, bibId);
+    if (hasStatus)
+      db.prepare(`UPDATE Status SET note = ? WHERE "bibId" = ?`).run(combinedNote, bibId);
   } catch (e) {
     if (e instanceof Error) {
       console.error(e.message);

--- a/src/main/database/timingRecords-db.ts
+++ b/src/main/database/timingRecords-db.ts
@@ -274,6 +274,9 @@ function updateTimeRecord(
     }
   }
 
+  // The row updated above is located by existingRecord.index; the incoming index can differ when
+  // records are merged by bib, so the note has to follow the same row.
+  record.index = existingRecord.index;
   processNote(record, dbStatus.SyncDirection.Incoming);
   dbStatus.SetProgress(record.bibId);
   const eventLogMessage = `[Update](Time): bibId: (${existingRecord.bibId})->(${record.bibId}), ${RecordStatus[record.status]}, merge:${merge}`;
@@ -329,7 +332,18 @@ function insertTimeRecord(record: TypedRunnerDB): DatabaseResponse {
     const stmt = db.prepare(
       `INSERT INTO TimeRecords (bibId, stationId, timeIn, timeOut, timeModified, sent, status) VALUES (?, ?, ?, ?, ?, ?, ?)`
     );
-    stmt.run(record.bibId, stationID, timeInISO, timeOutISO, modifiedISO, sent, status);
+    const result = stmt.run(
+      record.bibId,
+      stationID,
+      timeInISO,
+      timeOutISO,
+      modifiedISO,
+      sent,
+      status
+    );
+    // The renderer sends index 0 for a new record; the note is written by "index", so adopt the
+    // autoincremented rowid or the note would target a row that doesn't exist.
+    record.index = Number(result.lastInsertRowid);
   } catch (e) {
     if (e instanceof Error) {
       console.error(e.message);


### PR DESCRIPTION
Closes #119

Claude helped me find and solve two bugs:

1. New records saved the note against index 0 rather than the
   index SQLite actually assigned, so the note went nowhere.
2. Any bib without a Status row (athlete not in the roster)
   had its note thrown away completely.

Not Chromebook specific — reproduces anywhere. Tested adds,
edits, unknown bibs and duplicates.