### PR TITLE
fix: cleanup linting errors

### DIFF
--- a/electron-vite-resolver.cjs
+++ b/electron-vite-resolver.cjs
@@ -1,7 +1,7 @@
-const isCore = require("is-core-module");
-const resolve = require("resolve");
 const { execSync } = require("child_process");
 const path = require("path");
+const isCore = require("is-core-module");
+const resolve = require("resolve");
 
 /**
  * @typedef ResolverOptions
@@ -151,6 +151,17 @@ const resolvePath = (source, file, options) => {
     return resolveSync(source, resolveOptions, "AS IS");
   } catch (err) {
     log("COULD NOT RESOLVE AS IS", source);
+  }
+
+  // fall back to Node's own resolution, which (unlike the `resolve` package here) understands
+  // package.json "exports" maps, for exports-only packages such as uuid
+  try {
+    log("RESOLVING WITH NODE EXPORTS", source);
+    const resolvedPath = require.resolve(source, { paths: [resolveOptions.basedir] });
+    log("RESOLVED", resolvedPath);
+    return { found: true, path: resolvedPath };
+  } catch (err) {
+    log("COULD NOT RESOLVE WITH NODE EXPORTS", source);
   }
 
   // try to resolve the source with alias

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,11 +1,11 @@
+const { resolve } = require("path");
+const toolkitPrettier = require("@electron-toolkit/eslint-config-prettier");
+const toolkitTs = require("@electron-toolkit/eslint-config-ts");
 const js = require("@eslint/js");
-const react = require("eslint-plugin-react");
-const reactHooks = require("eslint-plugin-react-hooks");
 const importPlugin = require("eslint-plugin-import");
 const jsxA11y = require("eslint-plugin-jsx-a11y");
-const toolkitTs = require("@electron-toolkit/eslint-config-ts");
-const toolkitPrettier = require("@electron-toolkit/eslint-config-prettier");
-const { resolve } = require("path");
+const react = require("eslint-plugin-react");
+const reactHooks = require("eslint-plugin-react-hooks");
 
 module.exports = [
   {
@@ -24,6 +24,20 @@ module.exports = [
   importPlugin.flatConfigs.recommended,
   importPlugin.flatConfigs.typescript,
   jsxA11y.flatConfigs.recommended,
+  {
+    // TypeScript already checks undeclared identifiers and understands TS-only constructs
+    // (enum members, interface/type params); the base rules produce false positives here.
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      "no-undef": "off",
+      "no-unused-vars": "off",
+      // Disabled: fires on the valid TS pattern of reusing an identifier across the
+      // type and value namespaces (e.g. `interface Foo` + `const Foo = ...`).
+      "no-redeclare": "off",
+      "@typescript-eslint/no-redeclare": "off",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }]
+    }
+  },
   {
     settings: {
       react: {

--- a/src/main/api/rfid/interfaces/IRfid-controller.ts
+++ b/src/main/api/rfid/interfaces/IRfid-controller.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import { DeviceStatus } from "$shared/enums";
 import { RfidSettings } from "$shared/models";
 import type EventEmitter from "events";

--- a/src/main/api/rfid/zebra-fxr90/zebra-websocket-processor.ts
+++ b/src/main/api/rfid/zebra-fxr90/zebra-websocket-processor.ts
@@ -119,7 +119,6 @@ export class ZebraWebSocketProcessor {
   private eventEmitter: EventEmitter = new EventEmitter();
   private connectionPromise: Promise<void> | null = null;
   private resolveConnection: (() => void) | null = null;
-  // eslint-disable-next-line no-unused-vars
   private rejectConnection: ((error: Error) => void) | null = null;
   private processingPendingMessages = false;
   private pendingProcessingRequested = false;

--- a/src/main/database/runners-db.ts
+++ b/src/main/database/runners-db.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import path from "path";
 import { finished } from "stream/promises";
 import { parse } from "csv-parse";
 import { format } from "date-fns";
@@ -323,7 +324,6 @@ function parseCSVDate(timingDate: string): Date {
 
 export function exportUnsentRunnersAsCSV() {
   let queryResult;
-  const path = require("path");
   const stationId = appStore.get("station.id") as number;
   let fileIndex = appStore.get("incrementalFileIndex") as number;
 
@@ -444,7 +444,6 @@ export async function exportDropsAsCSV() {
 }
 
 function writeToCSV(filename: string, queryResult, incremental: boolean) {
-  const fs = require("fs");
   const eventName = appStore.get("event.name") as string;
   const stationIdentifier = appStore.get("station.identifier") as string;
 
@@ -502,7 +501,6 @@ function sanitizeNoteForExport(note: string | null | undefined): string {
 }
 
 function writeDropsToCSV(filename: string, queryResult) {
-  const fs = require("fs");
   const eventName = appStore.get("event.name") as string;
   const stationIdentifier = appStore.get("station.identifier") as string;
 

--- a/src/main/database/status-db.ts
+++ b/src/main/database/status-db.ts
@@ -366,13 +366,9 @@ export function syncNoteWithStatus(
   return [DatabaseStatus.Updated, message];
 }
 
-// SyncDirection members are only referenced via property access (here and cross-file), which
-// this lint rule can't trace, so it misreports them as unused.
 export enum SyncDirection {
-  /* eslint-disable no-unused-vars */
   Incoming,
   Outgoing
-  /* eslint-enable no-unused-vars */
 }
 
 export function SetProgress(bibId: number): DatabaseResponse {

--- a/src/main/lib/stat-engine.ts
+++ b/src/main/lib/stat-engine.ts
@@ -65,7 +65,7 @@ export function initStatEngine() {
   stats.addStat("errors", () => invalidResult);
   stats.addStat("duplicates", () => dbRunners.GetRunnersWithDuplicateStatus());
 
-  stats; // const engine: StatEngine<"defaultValue" | "inStation" | "throughStation">
+  // stats: StatEngine<"defaultValue" | "inStation" | "throughStation">
 
   stats.calculate();
 }

--- a/src/renderer/src/components/RenderMarkdown.tsx
+++ b/src/renderer/src/components/RenderMarkdown.tsx
@@ -5,6 +5,7 @@ import remarkToc from "remark-toc";
 
 type Props = Options & {
   trusted?: boolean;
+  className?: string;
 };
 
 export function RenderMarkdown(props: Props) {
@@ -18,7 +19,7 @@ export function RenderMarkdown(props: Props) {
     : [];
 
   return (
-    <div className={`markdown ${(props as any).className}`}>
+    <div className={`markdown ${props.className}`}>
       <Markdown
         {...props}
         // @ts-expect-error some odd quirk with remark plugins and typescript and declaring their options objects

--- a/src/renderer/src/features/RosterPage/RosterPage.tsx
+++ b/src/renderer/src/features/RosterPage/RosterPage.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
-
-import { getRouteApi, useNavigate } from "@tanstack/react-router";
+import { getRouteApi } from "@tanstack/react-router";
 import { StatusTag } from "~/components/StatusTag";
 import { useAthletes } from "~/hooks/data/useAthletes";
 import { AthleteProgress, DropReason } from "$shared/enums";
@@ -14,7 +12,7 @@ export function RosterPage() {
   const { data } = useAthletes();
 
   const { firstName, lastName } = routeApi.useSearch();
-  const navigate = useNavigate();
+  const navigate = routeApi.useNavigate();
 
   const columns: ColumnDef<AthleteStatusDB> = [
     {
@@ -80,7 +78,7 @@ export function RosterPage() {
         showFooter
         onClearFilters={() => {
           // TODO: For some reason this requires two clicks to re-render
-          navigate({ search: {} }); // TODO: fix TS2322
+          navigate({ search: () => ({}) });
         }}
         initialFilter={
           firstName && lastName ? { firstName: `${firstName} ${lastName}` } : undefined

--- a/src/renderer/src/features/SettingsPage/hooks/useRFIDStatus.ts
+++ b/src/renderer/src/features/SettingsPage/hooks/useRFIDStatus.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import { useEffect, useState } from "react";
 import { DeviceStatus } from "../../../../../shared/enums";
 import { useIpcRenderer } from "../../../hooks/useIpcRenderer";

--- a/src/renderer/src/features/Sidebar/SidebarButton.tsx
+++ b/src/renderer/src/features/Sidebar/SidebarButton.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { FunctionComponent, SVGProps, useRef } from "react";
 import { classed } from "@tw-classed/react";
 import { Stack } from "~/components";
@@ -53,15 +52,7 @@ export function SidebarButton(props: SidebarButtonProps) {
             height: buttonRect?.height ?? 0
           }}
         />
-        {
-          // TODO: fix TS2769
-          props.icon({
-            className: "mr-4 ml-1",
-            title: props.children,
-            height: 28,
-            width: 28
-          })
-        }
+        <props.icon className="mr-4 ml-1" title={props.children} height={28} width={28} />
         {props.children}
       </SidebarStack>
     </button>

--- a/src/renderer/src/hooks/useCountdown.tsx
+++ b/src/renderer/src/hooks/useCountdown.tsx
@@ -7,8 +7,7 @@ interface Options {
 export function useCountdown(count: number, options: Options = {}) {
   const [countdown, setCountdown] = useState(count);
 
-  // @ts-ignore
-  const intervalRef = useRef<NodeJS.Timeout>(); // TODO: fix TS2554
+  const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined);
 
   const resetCountdown = () => {
     setCountdown(count);


### PR DESCRIPTION
## Summary
Fixes #238. Root cause: `eslint.config.cjs` applied base ESLint rules (`no-undef`, `no-unused-vars`, `no-redeclare`) to TypeScript files, which do not understand TS-only constructs (enum members, interface method params, type/value namespace merging), producing ~103 mostly false-positive lint errors.

## Changes
- **Config**: disabled `no-undef`, `no-unused-vars`, and `no-redeclare` for `.ts`/`.tsx` files in `eslint.config.cjs` and enabled `@typescript-eslint/no-unused-vars` (with `_` prefix ignore pattern) instead.
- **Resolver**: fixed `electron-vite-resolver.cjs` to fall back to Node's own `require.resolve` (which understands package.json `exports` maps) when the `resolve` package fails, fixing `import/no-unresolved` for the `uuid` package.
- **Cleanup**: removed obsolete inline `eslint-disable` comments in `IRfid-controller.ts`, `zebra-websocket-processor.ts`, `status-db.ts`, and `useRFIDStatus.ts` that are no longer needed after the config fix.
- **Real fixes**: replaced `require()` with ES imports in `runners-db.ts`; removed a stray no-op expression in `stat-engine.ts`; removed an `any` cast in `RenderMarkdown.tsx`; fixed a bare `@ts-ignore` in `useCountdown.tsx`.
- **Type suppressions**: removed `@ts-nocheck` from `RosterPage.tsx` and `SidebarButton.tsx`, then fixed the real type errors that had been suppressed (route-scoped `navigate`/`search` reducer typing, and rendering an icon component as JSX instead of calling it as a plain function).

## Testing
- `pnpm exec eslint .` — passes clean
- `pnpm run typecheck:node` — passes
- `pnpm run typecheck:web` — passes
- `pnpm run build` — passes
