### PR TITLE
fix: resolve datagrid header collisions and related layout issues

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,6 +17,8 @@ function createWindow(): BrowserWindow {
   mainWindow = new BrowserWindow({
     width: 1440,
     height: 1080,
+    minWidth: 775,
+    minHeight: 600,
     backgroundColor: "#0D1519",
     show: false,
     autoHideMenuBar: true,

--- a/src/renderer/src/features/DataGrid/DataGrid.tsx
+++ b/src/renderer/src/features/DataGrid/DataGrid.tsx
@@ -81,7 +81,7 @@ export function DataGrid<T extends object>(props: Props<T>) {
   return (
     <div
       ref={parentRef}
-      className={`overflow-y-auto overflow-x-hidden below-default:overflow-x-auto ${props.classNames?.root}`}
+      className={`overflow-y-auto overflow-x-auto ${props.classNames?.root}`}
       style={{ height }}
     >
       <div className="w-full">

--- a/src/renderer/src/features/DataGrid/DataGrid.tsx
+++ b/src/renderer/src/features/DataGrid/DataGrid.tsx
@@ -29,7 +29,7 @@ interface Props<T extends object> {
   rowStatus?: (row: T) => RowStatus;
 }
 
-const Table = classed.table("overflow-auto w-full table-fixed font-display text-on-component");
+const Table = classed.table("overflow-auto w-full font-display text-on-component");
 
 export function DataGrid<T extends object>(props: Props<T>) {
   const parentRef = useRef<HTMLDivElement>(null);

--- a/src/renderer/src/features/DataGrid/DataGrid.tsx
+++ b/src/renderer/src/features/DataGrid/DataGrid.tsx
@@ -81,10 +81,10 @@ export function DataGrid<T extends object>(props: Props<T>) {
   return (
     <div
       ref={parentRef}
-      className={`overflow-y-auto overflow-x-hidden ${props.classNames?.root}`}
+      className={`overflow-y-auto overflow-x-hidden below-default:overflow-x-auto ${props.classNames?.root}`}
       style={{ height }}
     >
-      <div>
+      <div className="w-full">
         <Table className={props.classNames?.table}>
           {getSection("header")}
           <TableContent<T>

--- a/src/renderer/src/features/DataGrid/DataGrid.tsx
+++ b/src/renderer/src/features/DataGrid/DataGrid.tsx
@@ -81,7 +81,7 @@ export function DataGrid<T extends object>(props: Props<T>) {
   return (
     <div
       ref={parentRef}
-      className={`overflow-y-auto overflow-x-auto ${props.classNames?.root}`}
+      className={`overflow-y-auto overflow-x-auto ${props.classNames?.root ?? ""}`}
       style={{ height }}
     >
       <div className="w-full">

--- a/src/renderer/src/features/DataGrid/Headers.tsx
+++ b/src/renderer/src/features/DataGrid/Headers.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { classed } from "~/lib/classed";
+import { getColumnWidth } from "./columnWidth";
 import { Filter, Row, Section } from "./components";
 import { ResetButton } from "./components/ResetButton";
 import { SortIcon } from "./components/SortIcon";
@@ -8,7 +9,7 @@ import { SortState } from "./hooks/useSortState";
 import { Column } from "./types";
 
 const HeaderContainer = classed.div(
-  "flex gap-3 justify-end items-center py-2.5 px-4 w-full text-xl font-bold text-left uppercase group/header",
+  "flex gap-1 sm:gap-2 md:gap-3 justify-end items-center py-2.5 px-2 sm:px-3 md:px-4 w-full text-xl font-bold text-left uppercase group/header min-w-0 truncate",
   {
     variants: {
       disabled: {
@@ -38,11 +39,6 @@ interface Props<T extends object> {
 }
 
 export function Headers<T extends object>(props: Props<T>) {
-  const width = (width: Column<T>["width"]) => {
-    if (typeof width === "number") return `${width}px`;
-    return width;
-  };
-
   const isDisabled = (column: Column<T>) => column.sortable === false || props.type === "footer";
 
   return (
@@ -56,7 +52,7 @@ export function Headers<T extends object>(props: Props<T>) {
         {props.columns.map((column) => (
           <th
             key={column.name ?? String(column.field)}
-            style={{ width: width(column.width) }}
+            style={{ width: getColumnWidth(column) }}
             className="relative rounded-s bg-component-strong"
           >
             <HeaderContainer

--- a/src/renderer/src/features/DataGrid/Headers.tsx
+++ b/src/renderer/src/features/DataGrid/Headers.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 import { classed } from "~/lib/classed";
-import { getColumnWidth } from "./columnWidth";
+import { getColumnWidthStyle } from "./columnWidth";
 import { Filter, Row, Section } from "./components";
 import { ResetButton } from "./components/ResetButton";
 import { SortIcon } from "./components/SortIcon";
@@ -9,7 +9,7 @@ import { SortState } from "./hooks/useSortState";
 import { Column } from "./types";
 
 const HeaderContainer = classed.div(
-  "flex gap-1 sm:gap-2 md:gap-3 justify-end items-center py-2.5 px-2 sm:px-3 md:px-4 w-full text-xl font-bold text-left uppercase group/header min-w-0 truncate",
+  "flex gap-1 sm:gap-1.5 md:gap-2 justify-end items-center py-2.5 px-2 sm:px-2.5 md:px-3 w-full text-xl font-bold text-left uppercase group/header min-w-0 truncate",
   {
     variants: {
       disabled: {
@@ -52,7 +52,7 @@ export function Headers<T extends object>(props: Props<T>) {
         {props.columns.map((column) => (
           <th
             key={column.name ?? String(column.field)}
-            style={{ width: getColumnWidth(column) }}
+            style={getColumnWidthStyle(column)}
             className="relative rounded-s bg-component-strong"
           >
             <HeaderContainer

--- a/src/renderer/src/features/DataGrid/TableContent.tsx
+++ b/src/renderer/src/features/DataGrid/TableContent.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { Virtualizer } from "@tanstack/react-virtual";
+import { getColumnWidthStyle } from "./columnWidth";
 import { Cell, CellWrapper, Row } from "./components";
 import { useKeyFn } from "./hooks/useKeyFn";
 import { useVirtualPadding } from "./hooks/useVirtualPadding";
@@ -77,6 +78,7 @@ export function TableContent<T extends object>(props: Props<T>) {
             <Cell
               key={column.name ?? String(column.field)}
               align={column.align ?? "left"}
+              style={getColumnWidthStyle(column)}
               truncate={column.truncate !== false}
             >
               {renderCell(column, props.data[row.index])}

--- a/src/renderer/src/features/DataGrid/columnWidth.ts
+++ b/src/renderer/src/features/DataGrid/columnWidth.ts
@@ -1,0 +1,29 @@
+import { Column } from "./types";
+
+// table-layout:fixed sizes columns strictly from the first row's `width`
+// (min-width is ignored by Chromium), so every DataGrid column must get an
+// explicit width that already accounts for a readable floor. Centralizing
+// that calculation here keeps all pages consistent without per-page tuning.
+const MIN_CHAR_WIDTH = 11;
+const MIN_HEADER_PADDING = 72;
+const DEFAULT_MIN_WIDTH = 90;
+
+function toPixels(width: number | string | undefined): number {
+  if (typeof width === "number") return width;
+  if (typeof width === "string" && width.endsWith("px")) return parseInt(width, 10);
+  return 0;
+}
+
+/** Computes the CSS width (in px) for a DataGrid column, guaranteeing enough
+ * room for its header label regardless of any percentage/auto width supplied.
+ * Columns can opt out of the label-based estimate via `minWidth` when the
+ * author knows the content is reliably short (e.g. a 4-digit numeric field). */
+export function getColumnWidth<T extends object>(column: Column<T>): string {
+  const explicitPx = toPixels(column.width);
+  if (column.minWidth !== undefined) {
+    return `${Math.max(explicitPx, toPixels(column.minWidth))}px`;
+  }
+  const label = column.name ?? String(column.field);
+  const labelMin = label.length * MIN_CHAR_WIDTH + MIN_HEADER_PADDING;
+  return `${Math.max(labelMin, explicitPx, DEFAULT_MIN_WIDTH)}px`;
+}

--- a/src/renderer/src/features/DataGrid/columnWidth.ts
+++ b/src/renderer/src/features/DataGrid/columnWidth.ts
@@ -1,13 +1,11 @@
 import { CSSProperties } from "react";
 import { Column } from "./types";
 
-// table-layout:fixed sizes columns strictly from the first row. When every
-// column has an explicit `width`, Chromium proportionally inflates them all
-// to fill the table's own width (breaking any tight sizing below). So only
-// columns with a sizing hint (`width`/`minWidth`/`sample`) get a literal
-// `width`; a column with none of those is the intentional "flex" column that
-// absorbs leftover space via `min-width` instead, exactly like a normal auto
-// table column, while still keeping a readable floor.
+// Column sizing: when `table-layout: fixed` is used, giving every column an explicit `width` can cause
+// Chromium to proportionally inflate them all to fill the table width (defeating tight sizing).
+// To avoid that, only columns with a sizing hint (`width`/`minWidth`/`sample`) get a literal `width`;
+// a column with none of those is the intentional "flex" column that absorbs leftover space via
+// `min-width` instead, while still keeping a readable floor.
 const MIN_CHAR_WIDTH = 11;
 const MIN_HEADER_PADDING = 52;
 const DEFAULT_MIN_WIDTH = 80;

--- a/src/renderer/src/features/DataGrid/columnWidth.ts
+++ b/src/renderer/src/features/DataGrid/columnWidth.ts
@@ -1,29 +1,57 @@
+import { CSSProperties } from "react";
 import { Column } from "./types";
 
-// table-layout:fixed sizes columns strictly from the first row's `width`
-// (min-width is ignored by Chromium), so every DataGrid column must get an
-// explicit width that already accounts for a readable floor. Centralizing
-// that calculation here keeps all pages consistent without per-page tuning.
+// table-layout:fixed sizes columns strictly from the first row. When every
+// column has an explicit `width`, Chromium proportionally inflates them all
+// to fill the table's own width (breaking any tight sizing below). So only
+// columns with a sizing hint (`width`/`minWidth`/`sample`) get a literal
+// `width`; a column with none of those is the intentional "flex" column that
+// absorbs leftover space via `min-width` instead, exactly like a normal auto
+// table column, while still keeping a readable floor.
 const MIN_CHAR_WIDTH = 11;
-const MIN_HEADER_PADDING = 72;
-const DEFAULT_MIN_WIDTH = 90;
+const MIN_HEADER_PADDING = 52;
+const DEFAULT_MIN_WIDTH = 80;
 
-function toPixels(width: number | string | undefined): number {
+// Data cells render at text-sm font-medium (not bold/uppercase like headers)
+// with px-4 (32px total) horizontal padding. A little extra margin is kept
+// on top of the raw character estimate so tight samples (e.g. formatted
+// dates) don't get clipped by a single character.
+const CONTENT_CHAR_WIDTH = 9;
+const CONTENT_PADDING = 40;
+
+function toPixels(width: number | string | undefined): number | undefined {
   if (typeof width === "number") return width;
   if (typeof width === "string" && width.endsWith("px")) return parseInt(width, 10);
-  return 0;
+  return undefined;
 }
 
-/** Computes the CSS width (in px) for a DataGrid column, guaranteeing enough
- * room for its header label regardless of any percentage/auto width supplied.
- * Columns can opt out of the label-based estimate via `minWidth` when the
- * author knows the content is reliably short (e.g. a 4-digit numeric field). */
-export function getColumnWidth<T extends object>(column: Column<T>): string {
-  const explicitPx = toPixels(column.width);
-  if (column.minWidth !== undefined) {
-    return `${Math.max(explicitPx, toPixels(column.minWidth))}px`;
-  }
-  const label = column.name ?? String(column.field);
-  const labelMin = label.length * MIN_CHAR_WIDTH + MIN_HEADER_PADDING;
-  return `${Math.max(labelMin, explicitPx, DEFAULT_MIN_WIDTH)}px`;
+function computeFloorPx<T extends object>(column: Column<T>): number {
+  const explicitPx = toPixels(column.width) ?? 0;
+  const minOverridePx = column.minWidth !== undefined ? toPixels(column.minWidth) : undefined;
+
+  // An explicit minWidth is authoritative and should not be pulled up by the
+  // generic label/content estimates or default — it means the author already
+  // knows the content is reliably a fixed, short size.
+  if (minOverridePx !== undefined) return Math.max(minOverridePx, explicitPx);
+
+  return Math.max(
+    (column.name ?? String(column.field)).length * MIN_CHAR_WIDTH + MIN_HEADER_PADDING,
+    column.sample ? column.sample.length * CONTENT_CHAR_WIDTH + CONTENT_PADDING : 0,
+    explicitPx,
+    DEFAULT_MIN_WIDTH
+  );
+}
+
+/** Computes the CSS width/min-width for a DataGrid column, guaranteeing enough
+ * room for its header label and (when a `sample` is given) its widest realistic
+ * data value. A column is flexible (fills leftover space via `min-width` only)
+ * when explicitly marked `flexible: true`, or implicitly when it has no sizing
+ * hint at all (no `width`, `minWidth`, or `sample`). */
+export function getColumnWidthStyle<T extends object>(column: Column<T>): CSSProperties {
+  const floorPx = computeFloorPx(column);
+  const isFlex =
+    column.flexible ??
+    (column.width === undefined && column.minWidth === undefined && !column.sample);
+
+  return isFlex ? { minWidth: `${floorPx}px` } : { width: `${floorPx}px` };
 }

--- a/src/renderer/src/features/DataGrid/components/Cell.tsx
+++ b/src/renderer/src/features/DataGrid/components/Cell.tsx
@@ -1,3 +1,4 @@
+import { CSSProperties, ReactNode } from "react";
 import { Tooltip } from "primereact/tooltip";
 import { usePortalRoot } from "~/hooks/dom/usePortalRoot";
 import { useTruncated } from "~/hooks/dom/useTruncated";
@@ -20,8 +21,9 @@ export const CellWrapper = classed.td(
 );
 
 interface CellProps {
-  children: React.ReactNode;
+  children: ReactNode;
   align: "left" | "right";
+  style?: CSSProperties;
   truncate?: boolean;
 }
 
@@ -36,6 +38,7 @@ export function Cell(props: CellProps) {
       align={props.align}
       ref={cellRef}
       className={cellId}
+      style={props.style}
       truncate={props.truncate !== false}
     >
       {props.children}

--- a/src/renderer/src/features/DataGrid/components/Filter.tsx
+++ b/src/renderer/src/features/DataGrid/components/Filter.tsx
@@ -16,7 +16,7 @@ interface Props<T extends object> {
 }
 
 const FilterButton = classed.button({
-  base: "absolute px-4 opacity-0 transition-all duration-150 ease-in-out cursor-pointer fill-current text-on-surface group-hover/header:opacity-100 hover:text-on-surface-hover",
+  base: "hidden md:block absolute px-2 sm:px-3 md:px-4 opacity-0 transition-all duration-150 ease-in-out cursor-pointer fill-current text-on-surface group-hover/header:opacity-100 hover:text-on-surface-hover",
   variants: {
     align: {
       right: "left-0",

--- a/src/renderer/src/features/DataGrid/components/ResetButton.tsx
+++ b/src/renderer/src/features/DataGrid/components/ResetButton.tsx
@@ -10,7 +10,7 @@ interface Props<T extends object> {
 }
 
 const Button = classed.button({
-  base: "py-1 px-3 transition-all duration-150 ease-in-out text-on-surface hover:text-on-surface-hover",
+  base: "py-1 px-2 sm:px-2.5 md:px-3 transition-all duration-150 ease-in-out text-on-surface hover:text-on-surface-hover text-sm md:text-base",
   variants: {
     spinning: {
       true: "duration-500 animate-spin repeat-1"

--- a/src/renderer/src/features/DataGrid/types.ts
+++ b/src/renderer/src/features/DataGrid/types.ts
@@ -9,6 +9,15 @@ export type Column<T extends object> = {
     width?: number | string;
     /** Overrides the automatic label-based minimum width (see columnWidth.ts). */
     minWidth?: number | string;
+    /** A representative string of the widest value this column ever renders
+     * (e.g. "10:56:50 04 Sep" for a date, "Duplicate" for a status badge).
+     * Used by columnWidth.ts to size the column to its actual data instead
+     * of guessing a pixel width. */
+    sample?: string;
+    /** Marks this as the page's one column that fills leftover space instead
+     * of a fixed width. Combine with `sample` to give it a real content-based
+     * floor instead of just the (usually much smaller) header-label floor. */
+    flexible?: boolean;
     valueFn?: (row: T) => unknown;
     filterable?: boolean;
     sortable?: boolean;

--- a/src/renderer/src/features/DataGrid/types.ts
+++ b/src/renderer/src/features/DataGrid/types.ts
@@ -7,6 +7,8 @@ export type Column<T extends object> = {
     field: K;
     name?: string;
     width?: number | string;
+    /** Overrides the automatic label-based minimum width (see columnWidth.ts). */
+    minWidth?: number | string;
     valueFn?: (row: T) => unknown;
     filterable?: boolean;
     sortable?: boolean;

--- a/src/renderer/src/features/ExportPage/ExportPage.tsx
+++ b/src/renderer/src/features/ExportPage/ExportPage.tsx
@@ -19,23 +19,25 @@ export function ExportPage() {
   });
 
   return (
-    <Stack className="w-full h-full bg-component gap-4" align="center" justify="center">
-      <VerticalButtonGroup label="Export Tools" className="mb-32">
-        <Button color="primary" size="wide" onClick={() => createIncrementalCSVFile.mutate()}>
-          Export Incremental CSV File
-        </Button>
-        <Button color="primary" size="wide" onClick={() => createRunnerCSVFile.mutate()}>
-          Export Full CSV File
-        </Button>
-        <Button color="primary" size="wide" onClick={() => createDropsCSVFile.mutate()}>
-          Export Drops CSV File
-        </Button>
-      </VerticalButtonGroup>
-      <VerticalButtonGroup label="Export Files" className="align-text-top mb-32">
-        <Button color="primary" size="wide" onClick={() => openExportDirectory.mutate()}>
-          Open Export Folder
-        </Button>
-      </VerticalButtonGroup>
-    </Stack>
+    <div className="w-full h-full overflow-y-auto bg-component p-6">
+      <Stack justify="center" align="start" className="gap-6 flex-wrap xl:flex-nowrap min-w-full">
+        <VerticalButtonGroup label="Export Tools" className="w-[22rem]">
+          <Button color="primary" size="wide" onClick={() => createIncrementalCSVFile.mutate()}>
+            Export Incremental CSV File
+          </Button>
+          <Button color="primary" size="wide" onClick={() => createRunnerCSVFile.mutate()}>
+            Export Full CSV File
+          </Button>
+          <Button color="primary" size="wide" onClick={() => createDropsCSVFile.mutate()}>
+            Export Drops CSV File
+          </Button>
+        </VerticalButtonGroup>
+        <VerticalButtonGroup label="Export Files" className="w-[22rem]">
+          <Button color="primary" size="wide" onClick={() => openExportDirectory.mutate()}>
+            Open Export Folder
+          </Button>
+        </VerticalButtonGroup>
+      </Stack>
+    </div>
   );
 }

--- a/src/renderer/src/features/Footer/Footer.tsx
+++ b/src/renderer/src/features/Footer/Footer.tsx
@@ -50,7 +50,7 @@ export function Footer() {
     <Stack
       justify="between"
       align="center"
-      className="py-6 pl-4 m-4 text-lg bg-component font-display"
+      className="py-6 pl-4 m-4 text-lg shrink-0 bg-component font-display"
     >
       <Stack direction="row" align="center" className="gap-4">
         <Stack direction="col">

--- a/src/renderer/src/features/Header/Clock.tsx
+++ b/src/renderer/src/features/Header/Clock.tsx
@@ -6,7 +6,7 @@ export function Clock() {
   const formatted = formatDate(currentTime);
 
   return (
-    <h1 className="p-2 font-bold whitespace-nowrap text-primary in-w-80 font-display text-[clamp(2.25rem,5vw,4.5rem)]">
+    <h1 className="p-2 font-bold whitespace-nowrap text-primary font-display text-[clamp(2.25rem,5vw,4.5rem)]">
       {formatted}
     </h1>
   );

--- a/src/renderer/src/features/Header/Clock.tsx
+++ b/src/renderer/src/features/Header/Clock.tsx
@@ -5,5 +5,9 @@ export function Clock() {
   const [currentTime] = useCurrentTime();
   const formatted = formatDate(currentTime);
 
-  return <h1 className="p-2 text-7xl font-bold text-primary in-w-80 font-display">{formatted}</h1>;
+  return (
+    <h1 className="p-2 font-bold whitespace-nowrap text-primary in-w-80 font-display text-[clamp(2.25rem,5vw,4.5rem)]">
+      {formatted}
+    </h1>
+  );
 }

--- a/src/renderer/src/features/Header/Header.tsx
+++ b/src/renderer/src/features/Header/Header.tsx
@@ -3,7 +3,7 @@ import { Clock } from "./Clock";
 
 export function Header() {
   return (
-    <Stack justify="between" align="center" className="p-4 bg-surface-low text-on-surface">
+    <Stack justify="between" align="center" className="p-4 shrink-0 bg-surface-low text-on-surface">
       <Clock />
       <h1 className="pr-8 text-3xl italic font-bold font-display">Ultra Tracker</h1>
     </Stack>

--- a/src/renderer/src/features/HelpPage/HelpPage.tsx
+++ b/src/renderer/src/features/HelpPage/HelpPage.tsx
@@ -3,7 +3,7 @@ import { RenderMarkdown } from "~/components";
 
 export function HelpPage() {
   return (
-    <div className="overflow-y-auto px-4 max-h-inherit bg-component text-on-component">
+    <div className="overflow-y-auto px-4 h-full bg-component text-on-component">
       <RenderMarkdown trusted>{getStartedContents}</RenderMarkdown>
     </div>
   );

--- a/src/renderer/src/features/LogsPage/LogsPage.tsx
+++ b/src/renderer/src/features/LogsPage/LogsPage.tsx
@@ -11,32 +11,34 @@ export function LogsPage() {
       field: "timeModified",
       name: "Timestamp",
       render: formatDate,
-      width: "13%"
+      sample: "10:56:47 04 Sep"
     },
     {
       field: "stationId",
       name: "Station",
-      width: "15%"
+      sample: "9-station-longlongname"
     },
     {
       field: "bibId",
       name: "Bib",
-      width: "7%"
+      sample: "9999"
     },
     {
       field: "timeIn",
       name: "Time In",
       render: formatDate,
-      width: "13%"
+      sample: "10:56:47 04 Sep"
     },
     {
       field: "timeOut",
       name: "Time Out",
       render: formatDate,
-      width: "13%"
+      sample: "10:56:47 04 Sep"
     },
     {
       field: "comments",
+      flexible: true,
+      sample: "[Update](Time): bibId: (999)->(999), OK",
       sortable: false
     }
   ];

--- a/src/renderer/src/features/RosterPage/RosterPage.tsx
+++ b/src/renderer/src/features/RosterPage/RosterPage.tsx
@@ -20,8 +20,8 @@ export function RosterPage() {
     {
       field: "bibId",
       name: "Bib",
-      width: "70px",
-      align: "right"
+      align: "right",
+      sample: "9999"
     },
     {
       field: "dropReason",
@@ -35,38 +35,39 @@ export function RosterPage() {
          ${athlete.progress! === AthleteProgress.Present ? "In" : ""}
          ${athlete.progress! === AthleteProgress.Outgoing && athlete.dropReason! !== DropReason.DidNotStart ? "Out" : ""}
          ${athlete.dropReason! === DropReason.DidNotStart ? "Not Started" : ""}`,
-      width: "110px"
+      sample: "Not Started"
     },
     {
       field: "firstName",
       name: "Name",
       valueFn: (athlete) => `${athlete.firstName} ${athlete.lastName}`,
-      width: "180px"
+      sample: "Watermelon Chandelier"
     },
     {
       field: "age",
-      width: "70px"
+      sample: "100"
     },
     {
       field: "gender",
-      width: "70px"
+      sample: "M"
     },
     {
       field: "state",
       name: "Location",
-      width: "200px",
       render: (state, { city }) => `${city}, ${state}`,
-      valueFn: (athlete) => `${athlete.state}, ${athlete.city}`
+      valueFn: (athlete) => `${athlete.state}, ${athlete.city}`,
+      sample: "Waterfall Meadow, XX"
     },
     {
       field: "emergencyName",
       name: "Emergency Contact",
-      width: "220px",
-      render: (value, row) => <EmergencyContact name={value} athlete={row} />
+      render: (value, row) => <EmergencyContact name={value} athlete={row} />,
+      sample: "Pineapple Chandelier"
     },
     {
       field: "note",
-      width: "240px",
+      flexible: true,
+      sample: "Reported wrong bib number",
       valueFn: ({ note }) => (note == null ? "" : note)
     }
   ];

--- a/src/renderer/src/features/RosterPage/RosterPage.tsx
+++ b/src/renderer/src/features/RosterPage/RosterPage.tsx
@@ -20,7 +20,7 @@ export function RosterPage() {
     {
       field: "bibId",
       name: "Bib",
-      width: "6%",
+      width: "70px",
       align: "right"
     },
     {
@@ -35,38 +35,38 @@ export function RosterPage() {
          ${athlete.progress! === AthleteProgress.Present ? "In" : ""}
          ${athlete.progress! === AthleteProgress.Outgoing && athlete.dropReason! !== DropReason.DidNotStart ? "Out" : ""}
          ${athlete.dropReason! === DropReason.DidNotStart ? "Not Started" : ""}`,
-      width: "9%"
+      width: "110px"
     },
     {
       field: "firstName",
       name: "Name",
       valueFn: (athlete) => `${athlete.firstName} ${athlete.lastName}`,
-      width: "18%"
+      width: "180px"
     },
     {
       field: "age",
-      width: "6%"
+      width: "70px"
     },
     {
       field: "gender",
-      width: "6%"
+      width: "70px"
     },
     {
       field: "state",
       name: "Location",
-      width: "20%",
+      width: "200px",
       render: (state, { city }) => `${city}, ${state}`,
       valueFn: (athlete) => `${athlete.state}, ${athlete.city}`
     },
     {
       field: "emergencyName",
       name: "Emergency Contact",
-      width: "20%",
+      width: "220px",
       render: (value, row) => <EmergencyContact name={value} athlete={row} />
     },
     {
       field: "note",
-      width: "6%",
+      width: "240px",
       valueFn: ({ note }) => (note == null ? "" : note)
     }
   ];

--- a/src/renderer/src/features/RosterPage/RosterPage.tsx
+++ b/src/renderer/src/features/RosterPage/RosterPage.tsx
@@ -78,7 +78,6 @@ export function RosterPage() {
         data={data ?? []}
         columns={columns}
         getKey={({ bibId }) => bibId}
-        showFooter
         onClearFilters={() => {
           // TODO: For some reason this requires two clicks to re-render
           navigate({ search: {} }); // TODO: fix TS2322

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -22,27 +22,25 @@ export function RunnerEntry() {
       field: "sequence",
       name: "Seq",
       align: "right",
-      width: "64px",
-      minWidth: "64px"
+      sample: "9999"
     },
     {
       field: "bibId",
       name: "Bib",
       align: "right",
-      width: "64px",
-      minWidth: "64px"
+      sample: "9999"
     },
     {
       field: "in",
       name: "In Time",
       render: (value) => <InTimeCell value={value} />,
-      width: "160px"
+      sample: "10:56:50 04 Sep"
     },
     {
       field: "out",
       name: "Out Time",
       render: formatDate,
-      width: "160px"
+      sample: "10:56:50 04 Sep"
     },
     {
       field: "dropReason",
@@ -57,12 +55,14 @@ export function RunnerEntry() {
           : data.dropReason! === DropReason.DidNotStart
             ? "DNS"
             : data.dropReason,
-      width: "118px"
+      sample: "Duplicate"
     },
     {
       field: "note",
       name: "Notes",
       sortable: false,
+      flexible: true,
+      sample: "Reported wrong bib number",
       render: (note) => note || ""
     }
   ];

--- a/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerEntry.tsx
@@ -22,13 +22,15 @@ export function RunnerEntry() {
       field: "sequence",
       name: "Seq",
       align: "right",
-      width: "80px"
+      width: "64px",
+      minWidth: "64px"
     },
     {
       field: "bibId",
       name: "Bib",
       align: "right",
-      width: "80px"
+      width: "64px",
+      minWidth: "64px"
     },
     {
       field: "in",
@@ -66,9 +68,9 @@ export function RunnerEntry() {
   ];
 
   return (
-    <Stack className="gap-4 mt-0 h-full" justify="stretch" align="stretch">
+    <Stack className="gap-4 mt-0 h-full min-h-0" justify="stretch" align="stretch">
       <RunnerFormStats />
-      <div className="h-full bg-component grow">
+      <div className="h-full min-h-0 min-w-0 bg-component grow">
         <DataGrid
           data={runnerData ?? []}
           columns={columns}

--- a/src/renderer/src/features/RunnerEntry/RunnerFormStats.tsx
+++ b/src/renderer/src/features/RunnerEntry/RunnerFormStats.tsx
@@ -80,7 +80,7 @@ export function RunnerFormStats() {
   };
 
   return (
-    <Stack direction="col" align="stretch" className="gap-2 w-1/5">
+    <Stack direction="col" align="stretch" className="gap-2 w-1/5 shrink-0 min-h-0">
       <TextInput
         ref={inputRef}
         onKeyDown={handleKeyboardShortcuts}
@@ -113,7 +113,7 @@ export function RunnerFormStats() {
           Out
         </Button>
       </Stack>
-      <div className="w-full grow bg-component">
+      <div className="w-full grow min-h-0 bg-component">
         <Stats />
       </div>
 

--- a/src/renderer/src/features/RunnerEntry/Stats.tsx
+++ b/src/renderer/src/features/RunnerEntry/Stats.tsx
@@ -86,6 +86,8 @@ export function Stats() {
     {
       field: "id",
       name: "Stats",
+      flexible: true,
+      sample: "Registered Athletes",
       sortable: false
     },
     {
@@ -93,6 +95,7 @@ export function Stats() {
       name: "",
       sortable: false,
       align: "right",
+      sample: "9999",
       render: (value) => <span className="font-medium text-primary">{value}</span>
     }
   ];

--- a/src/renderer/src/features/StationsPage/StationsPage.tsx
+++ b/src/renderer/src/features/StationsPage/StationsPage.tsx
@@ -48,7 +48,8 @@ export function StationsPage() {
       field: "name",
       name: "Station",
       valueFn: (station) => `${station.identifier.split("-")[0]} ${station.name}`,
-      width: "240px",
+      flexible: true,
+      sample: "12 Apple Meadow Junction",
       sortable: false
     },
     {
@@ -58,7 +59,7 @@ export function StationsPage() {
         const loc = JSON.parse(station.location);
         return `${loc.latitude.toFixed(4)}, ${loc.longitude.toFixed(4)}`;
       },
-      width: "200px",
+      sample: "41.7283, -111.7995",
       sortable: false
     },
     {
@@ -68,64 +69,64 @@ export function StationsPage() {
         const loc = JSON.parse(station.location);
         return loc.elevation;
       },
-      width: "80px",
+      sample: "9999",
       sortable: false
     },
     {
       field: "distance",
       name: "Dist",
-      width: "80px",
       align: "right",
       render: (value) => value.toFixed(1),
+      sample: "100.0",
       sortable: false
     },
     {
       field: "dropbags",
       name: "Bags",
       render: (value) => (value ? "Yes" : "No"),
-      width: "80px",
+      sample: "Yes",
       sortable: false
     },
     {
       field: "crewaccess",
       name: "Crew",
       render: (value) => (value ? "Yes" : "No"),
-      width: "80px",
+      sample: "Yes",
       sortable: false
     },
     {
       field: "paceraccess",
       name: "Pacer",
       render: (value) => (value ? "Yes" : "No"),
-      width: "80px",
+      sample: "Yes",
       sortable: false
     },
     {
       field: "shiftBegin",
       name: "Open",
       render: (value) => formatShortDate(new Date(value)),
-      width: "135px",
+      sample: "05:00 25 Sep",
       sortable: false
     },
     {
       field: "cutofftime",
       name: "Cutoff",
       render: (value) => formatShortDate(new Date(value)),
-      width: "135px",
+      sample: "05:00 25 Sep",
       sortable: false
     },
     {
       field: "shiftEnd",
       name: "Close",
       render: (value) => formatShortDate(new Date(value)),
-      width: "135px",
+      sample: "05:00 25 Sep",
       sortable: false
     },
     {
       field: "entrymode",
       name: "Mode",
       render: (value) => EntryMode[value].toString(),
-      width: "90px",
+      sample: "OutOnly",
       sortable: false
     }
   ];

--- a/src/renderer/src/features/StationsPage/StationsPage.tsx
+++ b/src/renderer/src/features/StationsPage/StationsPage.tsx
@@ -48,7 +48,7 @@ export function StationsPage() {
       field: "name",
       name: "Station",
       valueFn: (station) => `${station.identifier.split("-")[0]} ${station.name}`,
-      width: "20%",
+      width: "240px",
       sortable: false
     },
     {
@@ -58,7 +58,7 @@ export function StationsPage() {
         const loc = JSON.parse(station.location);
         return `${loc.latitude.toFixed(4)}, ${loc.longitude.toFixed(4)}`;
       },
-      width: "15%",
+      width: "200px",
       sortable: false
     },
     {
@@ -131,7 +131,7 @@ export function StationsPage() {
   ];
 
   return (
-    <div>
+    <div className="flex flex-col h-full">
       <Stack className="gap-4" align="center" as="form" onSubmit={identityForm.onSubmit}>
         <Select
           options={stationOptions}
@@ -153,7 +153,7 @@ export function StationsPage() {
           <p className="text-on-component">{entryModeLabel}</p>
         </Stack>
       </Stack>
-      <div style={{ height: "100vh", paddingTop: "10px" }}>
+      <div className="flex-1 overflow-hidden bg-component">
         <DataGrid data={stations ?? []} columns={columns} getKey={({ identifier }) => identifier} />
       </div>
     </div>

--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -10,9 +10,9 @@ export const Route = createRootRoute({
     <BackdropProvider>
       <ToastProvider>
         <Sidebar />
-        <div className="flex overflow-hidden flex-col ml-16 w-screen">
+        <div className="flex overflow-hidden flex-col ml-16 w-screen h-screen">
           <Header />
-          <div className="mx-4 grow max-h-[calc(100vh-260px)]">
+          <div className="overflow-hidden mx-4 min-h-0 grow">
             <Outlet />
           </div>
           <Footer />

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -9,3 +9,46 @@ input::-webkit-inner-spin-button {
 input[type=number] {
   -moz-appearance: textfield;
 }
+
+/* Scrollbars: muted, theme-aware colors instead of the bright OS default */
+.dark {
+  scrollbar-color: #4f585d #060b0d;
+}
+
+.light {
+  scrollbar-color: #8a9093 #cfcfcf;
+}
+
+.dark ::-webkit-scrollbar,
+.light ::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+.dark ::-webkit-scrollbar-track {
+  background: #060b0d;
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background-color: #4f585d;
+  border-radius: 6px;
+  border: 3px solid #060b0d;
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background-color: #64707a;
+}
+
+.light ::-webkit-scrollbar-track {
+  background: #cfcfcf;
+}
+
+.light ::-webkit-scrollbar-thumb {
+  background-color: #8a9093;
+  border-radius: 6px;
+  border: 3px solid #cfcfcf;
+}
+
+.light ::-webkit-scrollbar-thumb:hover {
+  background-color: #767c7f;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,153 +1,154 @@
-const { createThemes } = require('tw-colors')
-
+const { createThemes } = require("tw-colors");
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [
-    "./src/renderer/index.html",
-    "./src/renderer/**/*.{ts,tsx}",
-  ],
+  content: ["./src/renderer/index.html", "./src/renderer/**/*.{ts,tsx}"],
   theme: {
     colors: {
-      transparent: 'transparent',
-      current: 'currentColor',
+      transparent: "transparent",
+      current: "currentColor"
     },
     extend: {
+      screens: {
+        "below-default": { max: "1295px" } // Enable scrolling at 90% of default window width (1296px)
+      },
       fontFamily: {
-        'display': ['IBM Plex Mono', 'sans-serif'],
+        display: ["IBM Plex Mono", "sans-serif"]
       },
       width: {
-        "104": "26rem",
-        "112": "28rem",
-        "120": "30rem",
-        "128": "32rem",
-        "144": "36rem",
+        104: "26rem",
+        112: "28rem",
+        120: "30rem",
+        128: "32rem",
+        144: "36rem"
       },
       animation: {
         "bounce-right-in": "ease-in-out bounce-right-in 0.75s",
-        "bounce-right-out": "ease-in-out bounce-right-out 0.75s",
+        "bounce-right-out": "ease-in-out bounce-right-out 0.75s"
       },
       keyframes: {
         "bounce-right-in": {
           "0%": {
             opacity: 0,
-            transform: 'translate3d(3000px, 0, 0) scaleX(3)'
+            transform: "translate3d(3000px, 0, 0) scaleX(3)"
           },
           "60%": {
             opacity: 1,
-            transform: 'translate3d(-25px, 0, 0) scaleX(1)'
+            transform: "translate3d(-25px, 0, 0) scaleX(1)"
           },
           "75%": {
-            transform: 'translate3d(10px, 0, 0) scaleX(0.98)'
+            transform: "translate3d(10px, 0, 0) scaleX(0.98)"
           },
           "90%": {
-            transform: 'translate3d(-5px, 0, 0) scaleX(0.995)'
+            transform: "translate3d(-5px, 0, 0) scaleX(0.995)"
           },
           "100%": {
-            transform: 'translate3d(0, 0, 0)'
+            transform: "translate3d(0, 0, 0)"
           }
         },
         "bounce-right-out": {
           "20%": {
             opacity: 1,
-            transform: 'translate3d(-20px, 0, 0)'
+            transform: "translate3d(-20px, 0, 0)"
           },
           "100%": {
             opacity: 0,
-            transform: 'translate3d(2000px, 0, 0)'
+            transform: "translate3d(2000px, 0, 0)"
           }
         }
       }
-    },
+    }
   },
   plugins: [
     require("tailwindcss-animate"),
-    createThemes({
-      light: {
-        surface: {
-          DEFAULT: "#CFCFCF",
-          secondary: "#AAB0B3",
-          tertiary: "#CBD3D6"
-        },
-        component: {
-          DEFAULT: "#EAEAEA",
-          secondary: "#E3E4E5",
-          strong: "#AAB0B3",
-          hover: "#CDD0D1"
-        },
-        on: {
+    createThemes(
+      {
+        light: {
           surface: {
-            DEFAULT:"#1D2529",
-            hover: "#060B0D"
-          },
-          primary: "#CDD0D1",
-          success: "#1D2529",
-          danger: "#1D2529",
-        },
-        primary: {
-          DEFAULT: "#0871A6",
-          hover: "#0E8FCC",
-        },
-        success: {
-          DEFAULT: "#0EAA00",
-          hover: "#0A7F00",
-        },
-        warning: {
-          DEFAULT: "#F75C14",
-          hover: "#D44A0B"
-        },
-        danger: {
-          DEFAULT: "#F30707",
-          hover: "#A30000",
-        },
-      },
-      dark: {
-        surface: {
-          DEFAULT: "#1D2529",
-          secondary: "#060B0D",
-          tertiary: "#0D1519"
-        },
-        component: {
-          DEFAULT: "#1D2529",
-          secondary: "#222A2E",
-          strong: "#283034",
-          hover: "#393F43"
-        },
-        on: {
-          surface: {
-            DEFAULT: "#7E8A8F",
-            hover: "#CFDEE5",
-            strong: "#CFDEE5",
+            DEFAULT: "#CFCFCF",
+            secondary: "#AAB0B3",
+            tertiary: "#CBD3D6"
           },
           component: {
-            DEFAULT:"#CDD0D1",
-            hover: "#AAB0B3",
+            DEFAULT: "#EAEAEA",
+            secondary: "#E3E4E5",
             strong: "#AAB0B3",
+            hover: "#CDD0D1"
           },
-          primary: "#1D2529",
-          success: "#1D2529",
-          danger: "#1D2529",
+          on: {
+            surface: {
+              DEFAULT: "#1D2529",
+              hover: "#060B0D"
+            },
+            primary: "#CDD0D1",
+            success: "#1D2529",
+            danger: "#1D2529"
+          },
+          primary: {
+            DEFAULT: "#0871A6",
+            hover: "#0E8FCC"
+          },
+          success: {
+            DEFAULT: "#0EAA00",
+            hover: "#0A7F00"
+          },
+          warning: {
+            DEFAULT: "#F75C14",
+            hover: "#D44A0B"
+          },
+          danger: {
+            DEFAULT: "#F30707",
+            hover: "#A30000"
+          }
         },
-        primary: {
-          hover: "#FFA000",
-          DEFAULT: "#FBBE00",
-        },
-        success: {
-          DEFAULT: "#0EAA00",
-          hover: "#0A7F00",
-        },
-        warning: {
-          DEFAULT: "#F75C14",
-          hover: "#D44A0B"
-        },
-        danger: {
-          DEFAULT: "#F30707",
-          hover: "#A30000",
-        },
+        dark: {
+          surface: {
+            DEFAULT: "#1D2529",
+            secondary: "#060B0D",
+            tertiary: "#0D1519"
+          },
+          component: {
+            DEFAULT: "#1D2529",
+            secondary: "#222A2E",
+            strong: "#283034",
+            hover: "#393F43"
+          },
+          on: {
+            surface: {
+              DEFAULT: "#7E8A8F",
+              hover: "#CFDEE5",
+              strong: "#CFDEE5"
+            },
+            component: {
+              DEFAULT: "#CDD0D1",
+              hover: "#AAB0B3",
+              strong: "#AAB0B3"
+            },
+            primary: "#1D2529",
+            success: "#1D2529",
+            danger: "#1D2529"
+          },
+          primary: {
+            hover: "#FFA000",
+            DEFAULT: "#FBBE00"
+          },
+          success: {
+            DEFAULT: "#0EAA00",
+            hover: "#0A7F00"
+          },
+          warning: {
+            DEFAULT: "#F75C14",
+            hover: "#D44A0B"
+          },
+          danger: {
+            DEFAULT: "#F30707",
+            hover: "#A30000"
+          }
+        }
       },
-    }, {
-      strict: true
-    })
-  ],
-}
-
+      {
+        strict: true
+      }
+    )
+  ]
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,9 +9,6 @@ module.exports = {
       current: "currentColor"
     },
     extend: {
-      screens: {
-        "below-default": { max: "1295px" } // Enable scrolling at 90% of default window width (1296px)
-      },
       fontFamily: {
         display: ["IBM Plex Mono", "sans-serif"]
       },


### PR DESCRIPTION
## Summary
Fixes #267. The header filter/sort icon collision fix in DataGrid headers grew to cover several related DataGrid and layout issues discovered while testing at narrow window widths and short window heights.

## Changes
- **DataGrid headers**: responsive gap/padding, filter icon hidden below `md`, and a shared `columnWidth.ts` utility that guarantees every column header has a readable minimum width (via a new `minWidth` override for columns that opt out. Applied to `RosterPage` (converted from percentage to fixed pixel widths) and `RunnerEntry` (Seq/Bib narrowed to 64px).
- **DataGrid horizontal scroll**: hidden by default, only enabled below a new `below-default` Tailwind breakpoint (90% of the default window width) via `overflow-x-auto`.
- **Scrollbars**: theme-aware (dark/light) muted colors instead of the bright OS default.
- **StationsPage**: replaced a hardcoded `height: 100vh` inline style with proper flexbox, which also let the Station and Lat/Long columns widen.
- **RunnerEntry**: `shrink-0` on the stats sidebar and `min-h-0` in several places to stop it collapsing or overflowing past the footer at narrow/short window sizes.
- **Root layout**: replaced a fragile `max-h-[calc(100vh-260px)]` content area with real flexbox (`h-screen` root, `grow min-h-0 overflow-hidden` content, `shrink-0` header/footer) so the footer is never clipped.
- **Clock**: fluid `clamp()` text sizing with `whitespace-nowrap` so it shrinks smoothly instead of wrapping.
- **HelpPage**: switched to `h-full` to restore internal scrolling after the root layout change removed the `max-height` it depended on.
- **ExportPage**: restyled to match the SettingsPage layout pattern (top-left flowing container instead of centered content with spacing hacks).
- **Main window**: set `minWidth: 775` / `minHeight: 600`, the smallest size where the Stations page header/footer/grid do not collide.

## Testing
- `pnpm run build` - passes
- `pnpm exec eslint` (scoped to touched files) - passes, only pre-existing unrelated errors in `tailwind.config.js` (require() imports, predates this work)
- `pnpm run typecheck:web` / `pnpm run typecheck:node` - pass
