### PR TITLE
fix(toast): prevent empty toast messages from being displayed

### DIFF
--- a/src/renderer/src/hooks/useHandleStatusToasts.tsx
+++ b/src/renderer/src/hooks/useHandleStatusToasts.tsx
@@ -32,10 +32,10 @@ export function useHandleStatusToasts<T>(specialToasts: ToastOnStatus<T> = {}) {
         case DatabaseStatus.Success:
           return true;
         case DatabaseStatus.NotFound:
-          createToast({ message, type: "warning" });
+          if (message) createToast({ message, type: "warning" });
           return false;
         case DatabaseStatus.Duplicate:
-          createToast({ message, type: "warning" });
+          if (message) createToast({ message, type: "warning" });
           return true;
         case DatabaseStatus.Error:
           createToast({ message, type: "danger" });


### PR DESCRIPTION
## Summary
Fixes #237. Empty toast appeared when navigating to Stations page with no station or event data in a fresh database. The fix adds guards to skip creating warning toasts when message text is empty for NotFound and Duplicate status codes.

## Changes
- Added message guards in useHandleStatusToasts to skip toast creation for empty messages

## Testing
- pnpm exec eslint src/renderer/src/hooks/useHandleStatusToasts.tsx — passes clean