### PR TITLE
fix: refine miscellaneous interface behavior

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -57,7 +57,7 @@ function createWindow(): BrowserWindow {
   let rendererCrashDialogOpen = false;
 
   mainWindow!.once("ready-to-show", () => {
-    uberLog(LogLevel.info, "ui", "Main window ready to show", true);
+    uberLog(LogLevel.info, "ui", "Main window ready to show", false);
     mainWindow!.show();
     mainWindow!.focus();
     mainWindow!.setTitle(`${app.name} - v${app.getVersion()}`);

--- a/src/renderer/src/components/Select.tsx
+++ b/src/renderer/src/components/Select.tsx
@@ -1,5 +1,6 @@
 import { ComponentProps } from "react";
 import { Dropdown } from "primereact/dropdown";
+import { twMerge } from "tailwind-merge";
 import WarningIcon from "~/assets/icons/warning-circle.svg?react";
 import { Stack } from "./Stack";
 import { Label } from "./TextInput";
@@ -38,7 +39,7 @@ export function Select(props: Props) {
     : props.options;
 
   return (
-    <Stack direction="col" className={`gap-1 ${props.className}`}>
+    <Stack direction="col" className={twMerge("gap-1 min-w-0", props.className)}>
       <Stack direction="row" align="center" className="gap-2.5">
         {props.label && <Label {...props.labelProps}>{props.label}</Label>}
         {props.error && (
@@ -46,7 +47,7 @@ export function Select(props: Props) {
         )}
       </Stack>
       <Dropdown
-        className={props.className}
+        className={twMerge("w-full min-w-0", props.className)}
         value={props.value}
         onChange={(event) => props.onChange(event.value)}
         filter={props.showFilter}
@@ -58,7 +59,10 @@ export function Select(props: Props) {
         {...(!isGrouped && { optionLabel: "name", optionValue: "value" })}
         pt={{
           input: {
-            className: !props.disabled ? "text-on-component" : "text-on-surface"
+            className: twMerge(
+              "whitespace-normal break-words",
+              !props.disabled ? "text-on-component" : "text-on-surface"
+            )
           }
         }}
       />

--- a/src/renderer/src/features/Footer/Footer.tsx
+++ b/src/renderer/src/features/Footer/Footer.tsx
@@ -64,17 +64,17 @@ export function Footer() {
 
         <Stack
           direction="col"
-          className="gap-[8px] px-[16px] py-[8px] text-[14px] border rounded-md border-component-strong bg-surface-tertiary"
+          className="gap-[8px] px-[16px] py-[8px] text-[14px] border rounded-md border-component-strong bg-surface-low"
         >
           <Stack id={internetTooltipId} direction="row" align="center" className="gap-[8px]">
-            <span className="text-on-component">Internet:</span>
+            <span className="text-on-surface">Internet:</span>
             {statusIcon(connectionStatus.checking, connectionStatus.internet)}
             <Tooltip position="top" target={`#${internetTooltipId}`}>
               {statusText(connectionStatus.checking, connectionStatus.internet)}
             </Tooltip>
           </Stack>
           <Stack id={openSplitTimeTooltipId} direction="row" align="center" className="gap-[8px]">
-            <span className="text-on-component">OpenSplitTime:</span>
+            <span className="text-on-surface">OpenSplitTime:</span>
             {statusIcon(connectionStatus.checking, connectionStatus.openSplitTime)}
             <Tooltip position="top" target={`#${openSplitTimeTooltipId}`}>
               {statusText(connectionStatus.checking, connectionStatus.openSplitTime)}

--- a/src/renderer/src/features/RunnerEntry/EditRunner.tsx
+++ b/src/renderer/src/features/RunnerEntry/EditRunner.tsx
@@ -40,7 +40,7 @@ const getErrorMessage = (error: FieldError): string => {
 };
 
 const getUploadStatusText = (runner: RunnerEx): string => {
-  const status = runner.openSplitTimePushStatus ?? (runner.sent ? "success" : "pending");
+  const status = runner.openSplitTimePushStatus ?? "pending";
   const statusText = status === "success" ? "Uploaded" : status === "error" ? "Error" : "Pending";
 
   return runner.openSplitTimePushError


### PR DESCRIPTION
## Summary
Refines several small operator-facing behaviors, including accurate OpenSplitTime upload state reporting.

## Changes
- **Runner entry**: show uploads without an OpenSplitTime status as pending rather than inferring a successful state from a sent record.
- **Controls**: make default selects use full available width and wrap long labels.
- **Footer**: visually mute the connection state so operational timing controls remain prominent.
- **Event log**: stop recording the main-window-ready message.

## Testing
- Not run: this Git PR workflow does not perform validation; prior validation is not asserted here.