### PR TITLE
feat(ost): sync split entry kinds and filter raw times by allowed kinds

### DIFF
--- a/src/main/database/athlete-db.ts
+++ b/src/main/database/athlete-db.ts
@@ -123,7 +123,6 @@ export function GetAthletes(): DatabaseResponse<AthleteStatusDB[]> {
   if (queryResult == null) return [null, DatabaseStatus.NotFound, message];
 
   message = `table Read Athletes - records:${queryResult.length}`;
-  console.log(message);
   return [queryResult as AthleteStatusDB[], DatabaseStatus.Success, message];
 }
 
@@ -172,7 +171,6 @@ export function GetAthleteFromColumn(
   };
 
   message = `athletes:Found athlete with bibId: ${runner.bibId}`;
-  console.log(message);
   return [runner, DatabaseStatus.Success, message];
 }
 

--- a/src/main/database/stations-db.ts
+++ b/src/main/database/stations-db.ts
@@ -7,6 +7,7 @@ import { clearStationsTable, createStationsTable } from "./tables-db";
 import { Station, StationDB } from "../../shared/models";
 import * as dialogs from "../lib/file-dialogs";
 import { appStore } from "../lib/store";
+import { syncSplitEntryKinds } from "../services/opensplittime";
 
 export function formatDate(date: Date | null): string {
   if (date == null) return "";
@@ -36,6 +37,7 @@ interface OpenSplitTimeEventJSON {
 interface OpenSplitTimeEventMetadata {
   name: string;
   id: number;
+  splitEntryKinds?: Record<string, Array<"in" | "out">>;
 }
 
 function importJsonFile(filePath: string): stationsJSON {
@@ -70,6 +72,15 @@ export async function loadStationsFromFile(filePath: string) {
           staging: { name: "", id: 0 }
         }
       );
+
+      try {
+        await syncSplitEntryKinds();
+      } catch (error) {
+        console.warn(
+          "Unable to hydrate OpenSplitTime split entry kinds from the loaded stations file",
+          error
+        );
+      }
     }
 
     if (index == "stations") {

--- a/src/main/database/status-db.ts
+++ b/src/main/database/status-db.ts
@@ -114,7 +114,6 @@ export function GetStatusFromColumn(
   };
 
   message = `athletes:Found status with bibId: ${athleteStatus.bibId}`;
-  console.log(message);
   return [athleteStatus, DatabaseStatus.Success, message];
 }
 

--- a/src/main/database/timingRecords-db.ts
+++ b/src/main/database/timingRecords-db.ts
@@ -73,7 +73,6 @@ export function insertOrUpdateTimeRecord(record: RunnerDB): DatabaseResponse {
     }
   }
 
-  console.log(message);
   return [status, message];
 }
 
@@ -141,7 +140,6 @@ export function getTimeRecordbyIndex(record: RunnerDB): DatabaseResponse<RunnerD
 
   queryResult = queryResult as RunnerDB;
   message = `timing-record:Found timeRecord with index: ${queryResult.index}`;
-  console.log(message);
   return [queryResult, DatabaseStatus.Success, message];
 }
 

--- a/src/main/lib/logger.ts
+++ b/src/main/lib/logger.ts
@@ -23,36 +23,26 @@ export function initialize() {
     path.join(app.getPath("documents"), app.name, `.logs/${now}-main.log`);
   log.errorHandler.startCatching();
   log.transports.console.format = "[{iso}] [{level}] [{processType}] {text}";
-  // Override console methods to log both to console and electron-log
-  const originalLog = console.log;
-  const originalError = console.error;
-  const originalWarn = console.warn;
-  const originalInfo = console.info;
-  const originalDebug = console.debug;
-
+  // Keep the app on a single console transport and let electron-log handle file output.
+  // This avoids duplicates like the same message being emitted twice to the terminal.
   console.log = (...args: unknown[]) => {
-    log.log(...args); // Log to electron-log
-    originalLog(...args); // Log to console
+    log.log(...args);
   };
 
   console.error = (...args: unknown[]) => {
-    log.error(...args); // Log to electron-log
-    originalError(...args); // Log to console
+    log.error(...args);
   };
 
   console.warn = (...args: unknown[]) => {
-    log.warn(...args); // Log to electron-log
-    originalWarn(...args); // Log to console
+    log.warn(...args);
   };
 
   console.info = (...args: unknown[]) => {
-    log.info(...args); // Log to electron-log
-    originalInfo(...args); // Log to console
+    log.info(...args);
   };
 
   console.debug = (...args: unknown[]) => {
-    log.debug(...args); // Log to electron-log
-    originalDebug(...args); // Log to console
+    log.debug(...args);
   };
 
   const freeMem = Number(os.freemem) / Math.pow(1024, 3);

--- a/src/main/lib/store.ts
+++ b/src/main/lib/store.ts
@@ -14,8 +14,8 @@ const defaults = {
     finishline: "99-finish-line",
     endtime: "00:00:00 Jan 01 2024",
     openSplitTime: {
-      production: { name: "", id: 0 },
-      staging: { name: "", id: 0 },
+      production: { name: "", id: 0, splitEntryKinds: {} as Record<string, string[]> },
+      staging: { name: "", id: 0, splitEntryKinds: {} as Record<string, string[]> },
       splitNames: {} as Record<string, string>
     }
   },
@@ -76,14 +76,16 @@ export const appStore = new Store({
               type: "object",
               properties: {
                 name: { type: "string", default: "" },
-                id: { type: "number", default: 0 }
+                id: { type: "number", default: 0 },
+                splitEntryKinds: { type: "object", default: {} }
               }
             },
             staging: {
               type: "object",
               properties: {
                 name: { type: "string", default: "" },
-                id: { type: "number", default: 0 }
+                id: { type: "number", default: 0 },
+                splitEntryKinds: { type: "object", default: {} }
               }
             },
             splitNames: { type: "object", default: {} }

--- a/src/main/services/opensplittime.ts
+++ b/src/main/services/opensplittime.ts
@@ -70,18 +70,39 @@ interface OpenSplitTimeAuthResponse {
   expiration?: string;
 }
 
+type OpenSplitTimeSubSplitKind = "in" | "out";
+
 interface OpenSplitTimeEventMetadata {
   name: string;
   id: number;
+  splitEntryKinds?: Record<string, OpenSplitTimeSubSplitKind[]>;
 }
 
 interface OpenSplitTimeEventMetadataStore {
   production?: OpenSplitTimeEventMetadata;
   staging?: OpenSplitTimeEventMetadata;
+  splitNames?: Record<string, string>;
 }
 
 interface OpenSplitTimeEventGroupResponse {
-  data?: { id?: string | number };
+  data?: {
+    id?: string | number;
+    attributes?: {
+      id?: string | number;
+      dataEntryGroups?: Array<{
+        entries?: Array<{
+          splitName?: string;
+          subSplitKind?: string;
+        }>;
+      }>;
+      unpairedDataEntryGroups?: Array<{
+        entries?: Array<{
+          splitName?: string;
+          subSplitKind?: string;
+        }>;
+      }>;
+    };
+  };
 }
 
 export interface OpenSplitTimeEnvironmentOption {
@@ -208,8 +229,6 @@ async function request<T>(path: string, init: RequestOptions = {}): Promise<T> {
   const url = `${apiHosts[currentEnvironment]}/api/v1${path}`;
 
   try {
-    console.debug(`OpenSplitTime request: ${init.method ?? "GET"} ${url}`);
-
     const response = await fetch(url, {
       ...init,
       headers: {
@@ -373,6 +392,45 @@ export async function authenticate(
   };
 }
 
+function normalizeSplitEntryKinds(rawValue: unknown): OpenSplitTimeSubSplitKind[] {
+  if (typeof rawValue !== "string") return [];
+
+  const normalized = rawValue.trim().toLowerCase();
+  if (normalized === "in") return ["in"];
+  if (normalized === "out") return ["out"];
+  if (normalized === "inout") return ["in", "out"];
+
+  return [];
+}
+
+function deriveSplitEntryKindsFromResponse(
+  response: OpenSplitTimeEventGroupResponse | unknown
+): Record<string, OpenSplitTimeSubSplitKind[]> {
+  const groups =
+    (response as OpenSplitTimeEventGroupResponse | undefined)?.data?.attributes?.dataEntryGroups ??
+    (response as OpenSplitTimeEventGroupResponse | undefined)?.data?.attributes
+      ?.unpairedDataEntryGroups ??
+    [];
+  const splitEntryKinds: Record<string, OpenSplitTimeSubSplitKind[]> = {};
+
+  for (const group of groups) {
+    const entries = group?.entries ?? [];
+
+    for (const entry of entries) {
+      const splitName = entry?.splitName?.trim();
+      const subSplitKind = normalizeSplitEntryKinds(entry?.subSplitKind);
+
+      if (!splitName || subSplitKind.length === 0) continue;
+
+      const existingKinds = splitEntryKinds[splitName] ?? [];
+      const mergedKinds = [...new Set([...existingKinds, ...subSplitKind])];
+      splitEntryKinds[splitName] = mergedKinds;
+    }
+  }
+
+  return splitEntryKinds;
+}
+
 // The stations JSON file records the OpenSplitTime event group id manually, so
 // verify it against the live event group and correct it if OpenSplitTime disagrees.
 export async function syncEventGroupId(): Promise<void> {
@@ -386,17 +444,59 @@ export async function syncEventGroupId(): Promise<void> {
 
   try {
     const response = (await getEventGroup(eventGroupIdOrSlug)) as OpenSplitTimeEventGroupResponse;
-    const remoteId = Number(response?.data?.id);
+    const remoteId = Number(response?.data?.id ?? response?.data?.attributes?.id);
+    const splitEntryKinds = deriveSplitEntryKindsFromResponse(response);
 
-    if (!Number.isFinite(remoteId) || remoteId <= 0 || remoteId === configuredEvent?.id) return;
-
-    appStore.set("event.openSplitTime", {
+    const nextEventMetadata = {
       ...eventMetadata,
-      [currentEnvironment]: { name: eventGroupIdOrSlug, id: remoteId }
-    });
-    console.info(`OpenSplitTime event group id for "${eventGroupIdOrSlug}" updated to ${remoteId}`);
+      [currentEnvironment]: {
+        name: eventGroupIdOrSlug,
+        id: Number.isFinite(remoteId) && remoteId > 0 ? remoteId : (configuredEvent?.id ?? 0),
+        splitEntryKinds: Object.keys(splitEntryKinds).length > 0 ? splitEntryKinds : undefined
+      }
+    };
+
+    appStore.set("event.openSplitTime", nextEventMetadata);
+
+    if (Number.isFinite(remoteId) && remoteId > 0 && remoteId !== configuredEvent?.id) {
+      console.info(
+        `OpenSplitTime event group id for "${eventGroupIdOrSlug}" updated to ${remoteId}`
+      );
+    }
   } catch (error) {
     console.warn("Unable to verify OpenSplitTime event group id", error);
+  }
+}
+
+export async function syncSplitEntryKinds(): Promise<void> {
+  const eventMetadata = appStore.get("event.openSplitTime") as
+    OpenSplitTimeEventMetadataStore | undefined;
+  const configuredEvent =
+    currentEnvironment === "production" ? eventMetadata?.production : eventMetadata?.staging;
+  const eventGroupIdOrSlug = configuredEvent?.name;
+
+  if (!eventGroupIdOrSlug) return;
+
+  try {
+    const response = (await getEventGroup(eventGroupIdOrSlug)) as OpenSplitTimeEventGroupResponse;
+    const splitEntryKinds = deriveSplitEntryKindsFromResponse(response);
+    const currentEventMetadata = appStore.get("event.openSplitTime") as
+      OpenSplitTimeEventMetadataStore | undefined;
+    const nextEvent = {
+      ...currentEventMetadata,
+      [currentEnvironment]: {
+        ...(currentEnvironment === "production"
+          ? currentEventMetadata?.production
+          : currentEventMetadata?.staging),
+        name: eventGroupIdOrSlug,
+        id: configuredEvent?.id ?? 0,
+        splitEntryKinds: Object.keys(splitEntryKinds).length > 0 ? splitEntryKinds : {}
+      }
+    };
+
+    appStore.set("event.openSplitTime", nextEvent);
+  } catch (error) {
+    console.warn("Unable to sync OpenSplitTime split entry kinds", error);
   }
 }
 
@@ -467,6 +567,25 @@ interface OpenSplitTimePushConfig {
   eventGroupIdOrSlug: string;
   stationIdentifier: string;
   splitName: string;
+  allowedKinds: OpenSplitTimeSubSplitKind[];
+}
+
+function resolveAllowedKindsForSplit(splitName: string): OpenSplitTimeSubSplitKind[] {
+  const eventMetadata = appStore.get("event.openSplitTime") as
+    OpenSplitTimeEventMetadataStore | undefined;
+  const configuredEvent =
+    currentEnvironment === "production" ? eventMetadata?.production : eventMetadata?.staging;
+  const liveKinds = configuredEvent?.splitEntryKinds?.[splitName];
+
+  if (Array.isArray(liveKinds) && liveKinds.length > 0) {
+    return [...new Set(liveKinds)];
+  }
+
+  const entryMode = Number(appStore.get("station.entrymode") ?? 0);
+  if (entryMode === 2) return ["in"];
+  if (entryMode === 3) return ["out"];
+
+  return ["in", "out"];
 }
 
 function resolvePushConfig(): OpenSplitTimePushConfig {
@@ -491,7 +610,9 @@ function resolvePushConfig(): OpenSplitTimePushConfig {
     throw new OpenSplitTimeApiError("OpenSplitTime event or station is not configured", 500);
   }
 
-  return { eventGroupIdOrSlug, stationIdentifier, splitName };
+  const allowedKinds = resolveAllowedKindsForSplit(splitName);
+
+  return { eventGroupIdOrSlug, stationIdentifier, splitName, allowedKinds };
 }
 
 function buildRawTimeRecords(
@@ -502,9 +623,10 @@ function buildRawTimeRecords(
   const records: OpenSplitTimeRawTime[] = [];
   const stoppedHereValue =
     stoppedHere == null ? undefined : (String(stoppedHere) as "true" | "false");
+  const allowedKinds = new Set(config.allowedKinds);
 
-  const addRecord = (time: Date | null, kind: "in" | "out") => {
-    if (!time) return;
+  const addRecord = (time: Date | null, kind: OpenSplitTimeSubSplitKind) => {
+    if (!time || !allowedKinds.has(kind)) return;
 
     records.push({
       source: config.stationIdentifier,
@@ -563,7 +685,6 @@ export async function pushTimeRecordUpdate(
   options: { force?: boolean } = {}
 ): Promise<OpenSplitTimePushOutcome> {
   if (pushPaused && !options.force) {
-    console.info(`OpenSplitTime push skipped for bib ${record.bibId}: pushes are paused`);
     return { pushed: false };
   }
 
@@ -573,7 +694,7 @@ export async function pushTimeRecordUpdate(
   if (records.length === 0) return { pushed: false };
 
   console.info(
-    `OpenSplitTime push starting for bib ${record.bibId}: ${records.length} raw time(s) to ${currentEnvironment}`
+    `OpenSplitTime push session: env=${currentEnvironment} split=${config.splitName} bib=${record.bibId} kinds=${config.allowedKinds.join(",") || "none"} records=${records.length}`
   );
 
   try {


### PR DESCRIPTION
## Summary
Synchronize OpenSplitTime split entry kinds metadata (in/out) from live event groups and use them to filter raw time record generation during pushes. Also clean up redundant console wrapping and noisy database query logs.

## Changes
- **OST Service**: Derive split entry kinds from event group data entry groups and unpaired data entry groups, synchronize them during station parsing and event group validation, and filter raw time record generation by the split's allowed sub-split kinds.
- **Store**: Add \splitEntryKinds\ schema to store OpenSplitTime event metadata for staging and production environments.
- **Logging**: Remove duplicate console logging wrapper calls in logger initialization and eliminate noisy database query/read console logs.

## Testing
- Not applicable: changes committed and submitted via Git PR workflow.