### PR TITLE
fix(db): revert to the actual schema version when a migration fails

### DIFF
--- a/src/main/database/tables-db.ts
+++ b/src/main/database/tables-db.ts
@@ -18,12 +18,16 @@ interface Table {
 }
 
 export function applyMigrations(db: Database.Database) {
+  // tracked outside the try so a failure can revert to the version the database
+  // was actually on, rather than assuming it was one step below the target
+  let currentVersion = db.pragma("user_version", { simple: true }) as number;
+
   try {
     console.log(`Applying database migrations`);
     for (let index = 0; index <= userVersion; index++) {
       if (index == 0) continue; // skip schema base revision
 
-      const currentVersion = db.pragma("user_version", { simple: true }) as number;
+      currentVersion = db.pragma("user_version", { simple: true }) as number;
       if (currentVersion == userVersion) return;
 
       const migrationVersion = currentVersion + 1;
@@ -35,8 +39,9 @@ export function applyMigrations(db: Database.Database) {
       db.pragma(`user_version = ${migrationVersion}`);
       console.log(`[success] pragma user_version: ${db.pragma("user_version", { simple: true })}`);
     }
-  } catch {
-    db.pragma(`user_version = ${Math.max(0, userVersion - 1)}`);
+  } catch (e: unknown) {
+    if (e instanceof Error) console.log(`Migration failed: ${e.message}`);
+    db.pragma(`user_version = ${currentVersion}`);
     console.log(
       `[error] pragma user_version: ${db.pragma("user_version", { simple: true })} reverted`
     );


### PR DESCRIPTION
Fixes the migration failure path described in #285.

## The bug

`applyMigrations` reverted `user_version` to `Math.max(0, userVersion - 1)`. `userVersion` is the hardcoded *target* constant (`const userVersion: number = 3`), not the version the database was actually on — so **any** failed migration stamped the database as `2`, whatever its real schema.

A v0 or v1 database that fails a migration therefore walks away labelled v2. `migrate()` picks its next step by reading `PRAGMA user_version` from the database itself (`@blackglory/better-sqlite3-migrations`, `getDatabaseVersion`), so the next launch attempts only migration 3 — which does `INSERT INTO Status_v3 (...) SELECT ... FROM Status`, and `Status` is created by migration **2**, which just got skipped. That fails, the catch stamps `2` again, and the database can never migrate on any subsequent launch.

Knock-on effect: migration 2 is what renames `StationEvents` → `TimeRecords`. Skip it and `validateDatabaseTables` creates a fresh empty `TimeRecords` while the real timing rows stay orphaned in `StationEvents` — not deleted, but invisible to the app.

The bare `catch {` also discarded the exception, so the SQLite reason for the original failure was never logged. That makes this very hard to diagnose from a user's log, which is most of why #285 is hard to chase.

## The fix

- Track `currentVersion` outside the `try` so the revert restores the version the database was actually on.
- `catch (e: unknown)` and log the underlying error, matching the `if (e instanceof Error)` style already used elsewhere in this file.

## Verification

Built a v0 database with a `status` column already present, so migration 1 is guaranteed to fail with `duplicate column name: status`, and ran the real app against it both ways:

| | logged reason | `user_version` after |
|---|---|---|
| before | *(none — swallowed)* | **2** ❌ |
| after | `duplicate column name: status` | **0** ✅ |

`pnpm typecheck` and eslint pass.

## Caveats

- This is the *failure handling*, not the initial failure. It doesn't explain what makes that first migration fail — it stops one failure from becoming permanent, and makes the real reason show up in the log so the underlying cause can be found.
- The failing migration itself already rolls back cleanly (the library wraps it in a transaction). The only thing written incorrectly was the version number; the damage landed on the *next* launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
