### PR TITLE
fix(database): handle legacy schema databases in migrations and metadata reads

### DIFF
--- a/src/main/database/event-databases-db.ts
+++ b/src/main/database/event-databases-db.ts
@@ -22,20 +22,31 @@ interface CountRow {
   count: number;
 }
 
+// Databases from older, unmigrated schema versions (e.g. legacy v2 event archives) may not
+// have these tables yet; migrations only run when the database is actually switched to.
+function tableExists(connection: Database.Database, tableName: string): boolean {
+  return (
+    connection
+      .prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(tableName) !== undefined
+  );
+}
+
 function readEventDatabaseMetadata(
   connection: Database.Database,
   slug: string,
   type: EventDatabaseMetadata["type"],
   filePath: string
 ): EventDatabaseMetadata {
-  const eventMeta = connection.prepare(`SELECT * FROM EventMeta LIMIT 1`).get() as
-    EventMetaRow | undefined;
-  const timingRecordCount = (
-    connection.prepare(`SELECT COUNT(*) AS count FROM TimeRecords`).get() as CountRow
-  ).count;
-  const athleteCount = (
-    connection.prepare(`SELECT COUNT(*) AS count FROM Athletes`).get() as CountRow
-  ).count;
+  const eventMeta = tableExists(connection, "EventMeta")
+    ? (connection.prepare(`SELECT * FROM EventMeta LIMIT 1`).get() as EventMetaRow | undefined)
+    : undefined;
+  const timingRecordCount = tableExists(connection, "TimeRecords")
+    ? (connection.prepare(`SELECT COUNT(*) AS count FROM TimeRecords`).get() as CountRow).count
+    : 0;
+  const athleteCount = tableExists(connection, "Athletes")
+    ? (connection.prepare(`SELECT COUNT(*) AS count FROM Athletes`).get() as CountRow).count
+    : 0;
 
   return {
     slug,

--- a/src/main/database/migrations-db.ts
+++ b/src/main/database/migrations-db.ts
@@ -1,14 +1,34 @@
 import { IMigration } from "@blackglory/better-sqlite3-migrations";
+import Database from "better-sqlite3";
 import * as tableDefs0 from "./schema/table-definitions-v0";
 import * as tableDefs2 from "./schema/table-definitions-v2";
 import * as tableDefs3 from "./schema/table-definitions-v3";
 
+// Some real-world databases have already reached a later table shape (e.g. via a build that
+// scaffolded current-shape tables without stamping a matching user_version pragma), so each
+// migration step below checks table/column state instead of assuming a fixed starting shape.
+function tableExists(db: Database.Database, tableName: string): boolean {
+  return (
+    db.prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?`).get(tableName) !==
+    undefined
+  );
+}
+
+function columnExists(db: Database.Database, tableName: string, columnName: string): boolean {
+  return (db.pragma(`table_info(${tableName})`) as Array<{ name: string }>).some(
+    (column) => column.name === columnName
+  );
+}
+
 export const migrations: IMigration[] = [
   {
     version: 1,
-    up: `
-        ALTER TABLE Athletes ADD COLUMN status INTEGER;
-      `,
+    up: (db: Database.Database) => {
+      if (tableExists(db, "Status")) return; // already split into Status; nothing to prepare
+      if (!columnExists(db, "Athletes", "status")) {
+        db.exec(`ALTER TABLE Athletes ADD COLUMN status INTEGER;`);
+      }
+    },
     down: `
         DROP TABLE Athletes;
         CREATE TABLE IF NOT EXISTS Athletes (
@@ -17,21 +37,39 @@ export const migrations: IMigration[] = [
   },
   {
     version: 2,
-    up: `
-        CREATE TABLE IF NOT EXISTS Status (
-          "index" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, ${tableDefs2.Status});
-        INSERT INTO Status (bibId, dns, dnf, dnfType, dnfStation, dnfDateTime, note, progress)
-          SELECT bibId, dns, dnf, dnfType, dnfStation, dnfDateTime, note, status FROM Athletes
-          WHERE EXISTS (SELECT 1 FROM Athletes LIMIT 1);
-        ALTER TABLE Athletes DROP COLUMN dns;
-        ALTER TABLE Athletes DROP COLUMN dnf;
-        ALTER TABLE Athletes DROP COLUMN dnfType;
-        ALTER TABLE Athletes DROP COLUMN dnfStation;
-        ALTER TABLE Athletes DROP COLUMN dnfDateTime;
-        ALTER TABLE Athletes DROP COLUMN note;
-        ALTER TABLE Athletes DROP COLUMN status;
-        ALTER TABLE StationEvents RENAME TO TimeRecords;
-        `,
+    up: (db: Database.Database) => {
+      if (!tableExists(db, "Status")) {
+        db.exec(`
+          CREATE TABLE IF NOT EXISTS Status (
+            "index" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, ${tableDefs2.Status});
+        `);
+        if (columnExists(db, "Athletes", "dns")) {
+          db.exec(`
+            INSERT INTO Status (bibId, dns, dnf, dnfType, dnfStation, dnfDateTime, note, progress)
+              SELECT bibId, dns, dnf, dnfType, dnfStation, dnfDateTime, note, status FROM Athletes
+              WHERE EXISTS (SELECT 1 FROM Athletes LIMIT 1);
+          `);
+        }
+      }
+
+      for (const column of [
+        "dns",
+        "dnf",
+        "dnfType",
+        "dnfStation",
+        "dnfDateTime",
+        "note",
+        "status"
+      ]) {
+        if (columnExists(db, "Athletes", column)) {
+          db.exec(`ALTER TABLE Athletes DROP COLUMN ${column};`);
+        }
+      }
+
+      if (tableExists(db, "StationEvents") && !tableExists(db, "TimeRecords")) {
+        db.exec(`ALTER TABLE StationEvents RENAME TO TimeRecords;`);
+      }
+    },
     down: `
         ALTER TABLE Athletes ADD COLUMN dns INTEGER;
         ALTER TABLE Athletes ADD COLUMN dnf INTEGER;
@@ -49,7 +87,8 @@ export const migrations: IMigration[] = [
   },
   {
     version: 3,
-    up: `
+    up: (db: Database.Database) => {
+      db.exec(`
         CREATE TABLE IF NOT EXISTS RFIDInbox (
           "index" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
           ${tableDefs3.RFIDInbox}
@@ -62,24 +101,32 @@ export const migrations: IMigration[] = [
           "index" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
           ${tableDefs3.OpenSplitTimePushStatus}
         );
-        CREATE TABLE IF NOT EXISTS Status_v3 (
-          "index" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, ${tableDefs3.Status});
-        INSERT INTO Status_v3 (bibId, dropped, dropReason, dropStation, dropDateTime, note, progress)
-          SELECT bibId,
-            CASE WHEN dns = 1 OR dnf = 1 THEN 1 ELSE 0 END,
-            CASE WHEN dns = 1 THEN 'did-not-start' WHEN dnf = 1 THEN dnfType ELSE NULL END,
-            CASE WHEN dnf = 1 THEN dnfStation ELSE NULL END,
-            CASE WHEN dnf = 1 THEN dnfDateTime ELSE NULL END,
-            note, progress
-          FROM Status
-          WHERE EXISTS (SELECT 1 FROM Status LIMIT 1);
-        DROP TABLE Status;
-        ALTER TABLE Status_v3 RENAME TO Status;
         CREATE TABLE IF NOT EXISTS Watchlist (
           "index" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, ${tableDefs3.Watchlist});
         CREATE TABLE IF NOT EXISTS EventMeta (
           "index" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, ${tableDefs3.EventMeta});
-      `,
+        DROP TABLE IF EXISTS StationEvents;
+      `);
+
+      // Only convert Status if it's still on the old dns/dnf shape; already-v3 databases skip this.
+      if (columnExists(db, "Status", "dns")) {
+        db.exec(`
+          CREATE TABLE IF NOT EXISTS Status_v3 (
+            "index" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, ${tableDefs3.Status});
+          INSERT INTO Status_v3 (bibId, dropped, dropReason, dropStation, dropDateTime, note, progress)
+            SELECT bibId,
+              CASE WHEN dns = 1 OR dnf = 1 THEN 1 ELSE 0 END,
+              CASE WHEN dns = 1 THEN 'did-not-start' WHEN dnf = 1 THEN dnfType ELSE NULL END,
+              CASE WHEN dnf = 1 THEN dnfStation ELSE NULL END,
+              CASE WHEN dnf = 1 THEN dnfDateTime ELSE NULL END,
+              note, progress
+            FROM Status
+            WHERE EXISTS (SELECT 1 FROM Status LIMIT 1);
+          DROP TABLE Status;
+          ALTER TABLE Status_v3 RENAME TO Status;
+        `);
+      }
+    },
     down: `
         DROP TABLE IF EXISTS EventMeta;
         DROP TABLE IF EXISTS Watchlist;


### PR DESCRIPTION
## Summary
Found while validating the scope of #283: legacy (pre-migration) event databases were reported as unreadable in the Event Manager, and databases with a stale user_version pragma but current-shape tables could crash mid-migration and leave the connection uninitialized.

## Changes
- **Event metadata**: add a tableExists() check before querying EventMeta/TimeRecords/Athletes, so legacy v2-schema archives no longer show as error: "unreadable" in the Event Manager list.
- **Migrations**: rewrite migrations 1-3's up steps as functions that check table/column existence via tableExists/columnExists before mutating, and drop orphaned legacy StationEvents tables in migration 3.
- Fixes crashes such as "no such column: dns" / "no such table: StationEvents" that previously cascaded into "Database connection not initialized" errors across stats, athlete table, and runners table views.

## Testing
- `pnpm exec eslint src/main/database/event-databases-db.ts src/main/database/migrations-db.ts` -- passes clean
- `pnpm run typecheck:node` -- passes clean
- Manually verified against three real user-provided SQLite database files (copies only): legacy v2-schema databases no longer marked unreadable, stale-user_version-but-current-shape databases migrate cleanly with no data loss, and already-correct databases are unaffected.
