### PR TITLE
feat(settings): add event archive reloader and update panel layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@ For a guide on how to set up an event using Ultra-Tracker, and advanced RFID con
 
 On first launch, Ultra-Tracker opens **Getting Started** to guide the user through starting an event for timing data collection.
 
-1. Select **Load Event File** and choose the event zip file supplied for the event. This
-   creates the local event database.
+1. Select **Load Event File** and choose the event file (`.zip`) supplied for the event.
 2. Select the station identifier for this computer.
 3. Select the operator callsign.
-5. Select the **Initial Drops** file, containing athletes known to have not started or dropped before the current station.
-6. Select **Import Event**. When the import finishes, go to the Stats page to begin logging.
+4. Select **Import Event**. When the import finishes, go to the Stats page to begin logging.
 
 The event files can be selected from their existing location; they do not need to be copied into a
 special folder first. The default event-config folder is `\Documents\Ultra-Tracker\.event-config\`.
@@ -206,7 +204,7 @@ This page allows the operator to manage event input files and the database neede
 
 ### OpenSplitTime
 
-OpenSplitTime is an optional integration for sending timing records directly to the selected event group. Configure the event group in the Stations file, then sign in on the Settings page with an OpenSplitTime steward account. Credentials may be saved using the operating system's secure credential storage. If both staging and production event groups are configured, select the environment before signing in. Production sends times to the live event and requires confirmation when switching from staging.
+OpenSplitTime is an optional integration for sending timing records directly to the configured event group. The configuration is done per event file, then sign in with an OpenSplitTime steward account that is a member of that event. Credentials can be saved between sessions. If both staging and production event groups are configured, select the environment before signing in. Production events send times to a live event and requires confirmation when switching from staging.
 
 While signed in, OpenSplitTime status takes precedence over CSV export status in the timing-record indicator. Use **Pause Pushes** to temporarily stop automatic uploads without signing out; **Resume Pushes** restarts them. **Sign Out** returns the indicator to the CSV export state and does not change whether a record has been exported.
 
@@ -227,12 +225,8 @@ While signed in, OpenSplitTime status takes precedence over CSV export status in
 
 The following is a description of each button's function. Each of these will open a file open dialog to the `\Documents\Ultra-Tracker\.event-config\` directory.
 
-#### Station Setup
+#### Drops File Import
 
-- **Load Stations File**
-  This loads a `JSON` file containing each of the stations and their detailed information to allow ease of selection while setting up this application. A typical filename will be `eventname-YYYY-stations.json`.
-- **Load Athletes File**
-  This function loads a `.csv` file, supplied by race organizers, containing all athletes registered or checked in for the event, whether they are known to have started _or not_.
 - **Load Drops File**
   This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** or **dropped from** the race (Withdrew, Timeout, Medical, Unknown).
 
@@ -256,6 +250,8 @@ The following is a description of each button's function. Each of these will ope
 
 #### Developer Tools
 
+- **Reload Events File**
+  This function reloads an event archive file (`.zip`), updating station data, athlete rosters, and initial drop records in the currently loaded event database.
 - **Recreate Database**
   This function is the means where _ALL_ **database entries and tables are removed** resulting in the loss of _ALL_ setup data and entry history! The intent is to allow recovery of a major database corruption event and the rapid rebuild and subsequent return to normal operation by the operator.
 - **Recover Data From CSV File**
@@ -266,9 +262,9 @@ The following is a description of each button's function. Each of these will ope
 > [!WARNING]
 > If instructed to do so, after the "Recreate Database" has been performed, perform the following steps:
 >
-> 1. Load the Stations file.
-> 1. Load the Athletes file.
-> 1. Load the Drops file.
+> 1. Create a new event using the Event Manager.
+> 1. Reload the event database file.
+> 1. Load the Drops file if applicable.
 > 1. Import a Full Export file using "Recover Data From CSV File".
 
 ### Local Database
@@ -290,6 +286,7 @@ Built as an Electron application using TypeScript + React + Tailwind CSS.
 
 > | <div style="width:200px;fontSize:larger">**Name**</div> | <div style="width:100px;fontSize:larger">**Call Sign**</div> | <div style="width:200px;> fontSize:larger">**GitHub**</div> |
 > | :------------------- | :----------- | :----------------------------------------------------- |
+> | **Paul Carter**      | KG7OKR       | [**cartpaul**](https://github.com/cartpauj)            |
 > | **Jaren Glenn**      | ---          | [**@derethil**](https://github.com/derethil)           |
 > | **David Leikis**     | KG7EW        | [**@DLeikis**](https://github.com/DLeikis)             |
 > | **Russ Leikis**      | KE7VFI       | [**@rleikis**](https://github.com/rleikis)             |

--- a/resources/config/event-archive-format.md
+++ b/resources/config/event-archive-format.md
@@ -25,7 +25,7 @@ so it must be present.
 
 ## `athletes.csv`
 
-Same schema accepted by the Settings page "Load Athletes File" import — header row:
+Same schema accepted by athlete roster imports — header row:
 
 ```
 Bib,First Name,Last Name,gender,age,city,state,emergency_name,emergency_phone

--- a/src/main/database/event-archive-db.ts
+++ b/src/main/database/event-archive-db.ts
@@ -10,6 +10,7 @@ import {
   readEventNameFromStationsContent
 } from "./stations-db";
 import { parseDropsContent } from "./status-db";
+import { selectEventArchiveFile } from "../lib/file-dialogs";
 
 const STATIONS_ENTRY = "stations.json";
 const ATHLETES_ENTRY = "athletes.csv";
@@ -89,5 +90,39 @@ export async function importEventArchiveFile(
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : "Unable to import event file";
     return [null, DatabaseStatus.Error, message];
+  }
+}
+
+export async function reloadEventArchiveFile(archiveFilePath?: string): Promise<string> {
+  let filePath = archiveFilePath;
+  if (!filePath) {
+    const filePaths = await selectEventArchiveFile();
+    filePath = filePaths?.[0];
+  }
+
+  if (!filePath) {
+    throw new Error("No event file selected");
+  }
+
+  const [entries, , message] = readEventArchiveEntries(filePath);
+  if (!entries) {
+    throw new Error(message || "Unable to read event file");
+  }
+
+  try {
+    const stationsJson = entries.stationsEntry.getData().toString("utf-8");
+    const eventName = readEventNameFromStationsContent(stationsJson);
+
+    await parseStationsContent(stationsJson, STATIONS_ENTRY);
+    await parseAthletesContent(Readable.from(entries.athletesEntry.getData()), ATHLETES_ENTRY);
+
+    if (entries.dropsEntry) {
+      await parseDropsContent(Readable.from(entries.dropsEntry.getData()), DROPS_ENTRY);
+    }
+
+    return `Reloaded event file "${eventName}"`;
+  } catch (e: unknown) {
+    const errMessage = e instanceof Error ? e.message : "Unable to reload event file";
+    throw new Error(errMessage);
   }
 }

--- a/src/main/ipc/dbsettings-ipc.ts
+++ b/src/main/ipc/dbsettings-ipc.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from "electron";
 import * as dbAthlete from "../database/athlete-db";
 import { getDatabaseConnection } from "../database/connect-db";
+import { reloadEventArchiveFile } from "../database/event-archive-db";
 import * as dbRunners from "../database/runners-db";
 import * as dbStations from "../database/stations-db";
 import * as dbStatus from "../database/status-db";
@@ -40,6 +41,10 @@ const clearDatabase: Handler<string> = () => {
   return result;
 };
 
+const reloadEventsFile: Handler<string> = () => {
+  return reloadEventArchiveFile();
+};
+
 export const initdbSettingsHandlers = () => {
   ipcMain.handle("load-athletes-file", loadAthletesFile);
   ipcMain.handle("load-stations-file", loadStationFile);
@@ -47,4 +52,5 @@ export const initdbSettingsHandlers = () => {
   ipcMain.handle("import-runners-file", importRunnersFile);
   ipcMain.handle("initialize-database", initializeDatabase);
   ipcMain.handle("clear-database", clearDatabase);
+  ipcMain.handle("reload-events-file", reloadEventsFile);
 };

--- a/src/renderer/src/assets/documents/get-started.md
+++ b/src/renderer/src/assets/documents/get-started.md
@@ -14,13 +14,10 @@
 
 On first launch, Ultra-Tracker opens **Getting Started** to guide the user through starting an event for timing data collection.
 
-1. Select **Load Stations File** and choose the stations JSON file supplied for the event. This
-   creates the local event database.
+1. Select **Load Event File** and choose the event file (`.zip`) supplied for the event.
 2. Select the station identifier for this computer.
 3. Select the operator callsign.
-4. Select the **Athletes** file supplied by the race organizers.
-5. Select the **Initial Drops** file, containing athletes known to have not started or dropped.
-6. Select **Import Event**. When the import finishes, go to the Stats page to begin logging.
+4. Select **Import Event**. When the import finishes, go to the Stats page to begin logging.
 
 The event files can be selected from their existing location; they do not need to be copied into a
 special folder first. The default event-config folder is `\Documents\Ultra-Tracker\.event-config\`.
@@ -42,8 +39,6 @@ The left side bar is used to select different pages. Select from Stats, Roster, 
 <a href="#ultra-tracker-help" style="color:steelblue;"><small>back to top</small></a>
 
 ---
-
-<a id="markdown-stats-page" name="stats-page"></a>
 
 ## Stats Page
 
@@ -87,6 +82,8 @@ Validation Rules:
 <div style="float: left">
    <img src="./img/stats.png">
 </div>
+
+<a id="markdown-stats-page" name="athlete-and-station-stats"></a>
 
 ### Athlete and Station stats
 
@@ -244,7 +241,7 @@ The Event Manager is used to switch between events and recover from local event 
 
 ---
 
-<a id="markdown-theme-page" name="theme-page"></a>
+<a id="markdown-theme-page" name="theme"></a>
 
 ## Theme
 
@@ -272,11 +269,16 @@ This page allows the operator to manage event input files and the database neede
 - **Linux:** `$HOME/Documents/ultra-tracker`
 - **MacOS:** `/Users/username/Documents/ultra-tracker`
 
-### OpenSplitTime
+#### Drops File Import
 
-OpenSplitTime is an optional integration for sending timing records directly to the selected event group. Configure the event group in the Stations file, then sign in with an OpenSplitTime steward account. Credentials may be saved using the operating system's secure credential storage. If both staging and production event groups are configured, select the environment before signing in. Production sends times to the live event and requires confirmation when switching from staging.
+- **Load Drops File**
+  This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** or **dropped from** the race (Withdrew, Timeout, Medical, Unknown).
 
-While signed in, OpenSplitTime status takes precedence over CSV export status in the timing-record indicator. Use **Pause Pushes** to temporarily stop automatic uploads without signing out; **Resume Pushes** restarts them. **Sign Out** returns the indicator to the CSV export state and does not change whether a record has been exported.
+  As an event proceeds more Drops will be recorded and new Drops files will be supplied to stations.
+
+  Importing new Drops files will update all athletes recorded as dropped at or before the current station; drops past the current station are ignored. This provides insight of which athletes are still expected into the current station.
+
+<a id="markdown-user-settings" name="user-settings"></a>
 
 ### User Settings
 
@@ -292,23 +294,31 @@ While signed in, OpenSplitTime status takes precedence over CSV export status in
 
 The following is a description of each button's function. Each of these will open a file open dialog to the `\Documents\Ultra-Tracker\.event-config\` directory.
 
-#### Station Setup
+<a id="markdown-ost-integration" name="opensplittime-integration"></a>
 
-- **Load Stations File**
-  This loads a `JSON` file containing each of the stations and their detailed information to allow ease of selection while setting up this application. A typical filename will be `eventname-YYYY-stations.json`.
-- **Load Athletes File**
-  This function loads a `.csv` file, supplied by race organizers, containing all athletes registered or checked in for the event, whether they are known to have started _or not_.
-- **Load Drops File**
-  This function loads a `.csv` file, supplied by race organizers, containing all of the athletes known to have **not started** or **dropped from** the race (Withdrew, Timeout, Medical, Unknown).
+### OpenSplitTime Integration
 
-  As an event proceeds more Drops will be recorded and new Drops files will be supplied to stations.
+OpenSplitTime is an optional integration for sending timing records directly to the configured event group. The configuration is done per event file, then sign in with an OpenSplitTime steward account that is a member of that event. Credentials can be saved between sessions. If both staging and production event groups are configured, select the environment before signing in. Production events send times to a live event and requires confirmation when switching from staging.
 
-  Importing new Drops files will update all athletes recorded as dropped at or before the current station; drops past the current station are ignored. This provides insight of which athletes are still expected into the current station.
+While signed in, OpenSplitTime status takes precedence over CSV export status in the timing-record indicator. Use **Pause Pushes** to temporarily stop automatic uploads without signing out; **Resume Pushes** restarts them. **Sign Out** returns the indicator to the CSV export state and does not change whether a record has been exported.
 
 #### RFID Configuration
 
 - **Initialize RFID**
   Starts and stops a RFID reader service for the Zebra FXR90 hardware. These controls are enabled only for Start and Finish Line stations only. Integrations with more RFID hardware will be possible in the future.
+
+<a id="markdown-developer-tools" name="developer-tools"></a>
+
+#### Developer Tools
+
+- **Reload Events File**
+  This function reloads an event archive file (`.zip`), updating station data, athlete rosters, and initial drop records in the currently loaded event database.
+- **Recreate Database**
+  This function is the means where _ALL_ **database entries and tables are removed** resulting in the loss of _ALL_ setup data and entry history! The intent is to allow recovery of a major database corruption event and the rapid rebuild and subsequent return to normal operation by the operator.
+- **Recover Data From CSV File**
+  This function imports **ALL of the entries** that have previously been made by the operator since the start of this race event! The Ultra-Tracker application has been automatically producing a file containing EVERY entry made by the operator continuously during normal operation! This function will restore all of this data to restore the program to the previous state automatically.
+
+<a id="markdown-app-settings" name="application-settings"></a>
 
 #### Application Settings
 
@@ -320,26 +330,21 @@ The following is a description of each button's function. Each of these will ope
 - **Linux:** `~/.config/ultra-tracker`
 - **MacOS:** `~/Library/Application Support/ultra-tracker`
 
-#### Developer Tools
-
-- **Recreate Database**
-  This function is the means where _ALL_ **database entries and tables are removed** resulting in the loss of _ALL_ setup data and entry history! The intent is to allow recovery of a major database corruption event and the rapid rebuild and subsequent return to normal operation by the operator.
-- **Recover Data From CSV File**
-  This function imports **ALL of the entries** that have previously been made by the operator since the start of this race event! The Ultra-Tracker application has been automatically producing a file containing EVERY entry made by the operator continuously during normal operation! This function will restore all of this data to restore the program to the previous state automatically.
-
 <a id="markdown-recovery-procedure" name="station-recovery-procedure"></a>
 
-### Station Recovery Procedure
+#### Station Recovery Procedure
 
 **If instructed to do so,**
 <span style="color:orange">after **Recreate Database** has been performed, perform the following steps:</span>
 
-1. Load the Stations file.
-1. Load the Athletes file.
-1. Load the Drops file.
-1. Import a Full Export file using "Recover Data From CSV File".
+1. Create a new event using the Event Manager.
+2. Reload the event database file.
+3. Load the Drops file if applicable.
+4. Import a Full Export file using "Recover Data From CSV File".
 
-### Local Database
+<a id="markdown-local-database" name="local-database"></a>
+
+#### Local Database
 
 Ultra-Tracker runs a SQLite database on the local machine. All transactions are preserved immediately and the operator can close and re-open the app without loss of data. A background task backs up the database to a secondary file, every 5 minutes. This backup is used for emergency use only and may not restore all data in a data-loss event. _Do not modify the local database files using external tools!_
 
@@ -366,13 +371,14 @@ Built as an Electron application using TypeScript + React + Tailwind CSS.
 
 > | <div style="width:200px;fontSize:larger">**Name**</div> | <div style="width:100px;fontSize:larger">**Call Sign**</div> | <div style="width:200px;> fontSize:larger">**GitHub**</div> |
 > | :------------------------------------------------------ | :----------------------------------------------------------- | :---------------------------------------------------------- |
-> | **Jaren Glenn**                                         | ---                                                          | [**@derethil**](https://github.com/derethil)                |
-> | **David Leikis**                                        | KG7EW                                                        | [**@DLeikis**](https://github.com/DLeikis)                  |
-> | **Russ Leikis**                                         | KE7VFI                                                       | [**@rleikis**](https://github.com/rleikis)                  |
-> | **Jorden Luke**                                         | KF7YEM                                                       | [**@JordenLuke**](https://github.com/JordenLuke)            |
-> | **Brian Marble**                                        | KG7AFQ                                                       | [**@brianmarble**](https://github.com/brianmarble)          |
-> | **Mitch Smith**                                         | N8MLS                                                        | [**@pxls2prnt**](https://github.com/pxls2prnt)              |
-> | **Brandon Tibbitts**                                    | KD7IIW                                                       | [**@Tibbs327**](https://github.com/Tibbs327)                |
+> | **Paul Carter**      | KG7OKR       | [**@cartpaul**](https://github.com/cartpauj)        |
+> | **Jaren Glenn**      | ---          | [**@derethil**](https://github.com/derethil)       |
+> | **David Leikis**     | KG7EW        | [**@DLeikis**](https://github.com/DLeikis)         |
+> | **Russ Leikis**      | KE7VFI       | [**@rleikis**](https://github.com/rleikis)         |
+> | **Jorden Luke**      | KF7YEM       | [**@JordenLuke**](https://github.com/JordenLuke)   |
+> | **Brian Marble**     | KG7AFQ       | [**@brianmarble**](https://github.com/brianmarble) |
+> | **Mitch Smith**      | N8MLS        | [**@pxls2prnt**](https://github.com/pxls2prnt)     |
+> | **Brandon Tibbitts** | KD7IIW       | [**@Tibbs327**](https://github.com/Tibbs327)       |
 
 <a id="markdown-license" name="license"></a>
 

--- a/src/renderer/src/features/SettingsPage/SettingsPage.tsx
+++ b/src/renderer/src/features/SettingsPage/SettingsPage.tsx
@@ -19,21 +19,57 @@ export function SettingsPage() {
   return (
     <div className="w-full h-full overflow-y-auto bg-component p-6">
       <Stack justify="center" align="start" className="gap-6 flex-wrap xl:flex-nowrap min-w-full">
-        {/* Event Settings */}
+        {/* Event Settings & User Settings */}
         <Stack direction="col" className="w-[22rem] gap-4" align="stretch">
-          <VerticalButtonGroup label="Event File Import">
-            <Button size="wide" onClick={() => settingsMutations.importStationsFile.mutate()}>
-              Load Stations File
-            </Button>
-            <Button size="wide" onClick={() => settingsMutations.importAthletesFile.mutate()}>
-              Load Athletes File
-            </Button>
+          <VerticalButtonGroup label="Drops File Import">
             <Button size="wide" onClick={() => settingsMutations.importDropsFile.mutate()}>
               Load Drops File
             </Button>
           </VerticalButtonGroup>
           <div className="border-t border-component-strong pt-4">
-            <RfidConfiguration />
+            <VerticalButtonGroup label="User Settings">
+              <Stack align="center" className="gap-3">
+                <Button size="md" onClick={gridFontScale.decrease}>
+                  A-
+                </Button>
+                <span className="w-16 text-center font-display text-on-surface-strong">
+                  {Math.round(gridFontScale.scale * 100)}%
+                </span>
+                <Button size="md" onClick={gridFontScale.increase}>
+                  A+
+                </Button>
+              </Stack>
+              <Button size="wide" onClick={gridFontScale.reset}>
+                Reset Grid Text Size
+              </Button>
+              <p className="w-80 text-on-surface-strong italic font-display text-sm mt-2">
+                Adjusts text size in data grids. You can also use Ctrl/Cmd + = / - / 0.
+              </p>
+              <div className="w-80 mt-4 border-t border-component-strong pt-4">
+                <Button
+                  size="wide"
+                  variant={inOutButton.enabled ? "solid" : "outlined"}
+                  className={inOutButton.enabled ? "" : "opacity-50"}
+                  aria-pressed={inOutButton.enabled}
+                  onClick={() => inOutButton.setEnabled(!inOutButton.enabled)}
+                >
+                  {inOutButton.enabled ? "Hide +/- Button" : "Show +/- Button"}
+                </Button>
+              </div>
+              <div className="w-80 mt-4 border-t border-component-strong pt-4">
+                <Button
+                  size="wide"
+                  variant={eventManagerOnStartup.enabled ? "solid" : "outlined"}
+                  className={eventManagerOnStartup.enabled ? "" : "opacity-50"}
+                  aria-pressed={eventManagerOnStartup.enabled}
+                  onClick={() => eventManagerOnStartup.setEnabled(!eventManagerOnStartup.enabled)}
+                >
+                  {eventManagerOnStartup.enabled
+                    ? "Disable Open Event Manager on Startup"
+                    : "Enable Open Event Manager on Startup"}
+                </Button>
+              </div>
+            </VerticalButtonGroup>
           </div>
         </Stack>
 
@@ -42,72 +78,41 @@ export function SettingsPage() {
           <OpenSplitTimeLogin className="w-full" />
         </Stack>
 
-        {/* User Settings + Developer Tools */}
+        {/* RFID Configuration + Developer Tools + App Settings */}
         <Stack direction="col" className="w-[22rem] gap-4" align="stretch">
-          <VerticalButtonGroup label="User Settings">
-            <Stack align="center" className="gap-3">
-              <Button size="md" onClick={gridFontScale.decrease}>
-                A-
-              </Button>
-              <span className="w-16 text-center font-display text-on-surface-strong">
-                {Math.round(gridFontScale.scale * 100)}%
-              </span>
-              <Button size="md" onClick={gridFontScale.increase}>
-                A+
-              </Button>
-            </Stack>
-            <Button size="wide" onClick={gridFontScale.reset}>
-              Reset Grid Text Size
-            </Button>
-            <p className="w-80 text-on-surface-strong italic font-display text-sm mt-2">
-              Adjusts text size in data grids. You can also use Ctrl/Cmd + = / - / 0.
-            </p>
-            <div className="w-80 mt-4 border-t border-component-strong pt-4">
-              <Button
-                size="wide"
-                variant={inOutButton.enabled ? "solid" : "outlined"}
-                className={inOutButton.enabled ? "" : "opacity-50"}
-                aria-pressed={inOutButton.enabled}
-                onClick={() => inOutButton.setEnabled(!inOutButton.enabled)}
-              >
-                {inOutButton.enabled ? "Hide +/- Button" : "Show +/- Button"}
-              </Button>
-            </div>
-            <div className="w-80 mt-4 border-t border-component-strong pt-4">
-              <Button
-                size="wide"
-                variant={eventManagerOnStartup.enabled ? "solid" : "outlined"}
-                className={eventManagerOnStartup.enabled ? "" : "opacity-50"}
-                aria-pressed={eventManagerOnStartup.enabled}
-                onClick={() => eventManagerOnStartup.setEnabled(!eventManagerOnStartup.enabled)}
-              >
-                {eventManagerOnStartup.enabled
-                  ? "Disable Open Event Manager on Startup"
-                  : "Enable Open Event Manager on Startup"}
-              </Button>
-            </div>
-          </VerticalButtonGroup>
+          <RfidConfiguration />
 
-          <VerticalButtonGroup label="Developer Tools" className="border-2 border-danger/30">
-            <Stack direction="col" className="gap-2">
-              <p className="w-80 text-on-surface-strong italic font-display text-sm font-bold mt-2 mb-4">
-                These are destructive operations! Under most circumstances you should not do this
-                unless instructed to.
-              </p>
-              <Button color="danger" size="wide" onClick={() => setRecreateOpen(true)}>
-                Recreate Database
-              </Button>
-              <Button color="danger" size="wide" onClick={() => setRecoverOpen(true)}>
-                Recover Data from CSV File
-              </Button>
-            </Stack>
-          </VerticalButtonGroup>
+          <div className="border-t border-component-strong pt-4">
+            <VerticalButtonGroup label="Developer Tools" className="border-2 border-danger/30">
+              <Stack direction="col" className="gap-2">
+                <p className="w-80 text-on-surface-strong italic font-display text-sm font-bold mt-2 mb-4">
+                  These are destructive operations! Under most circumstances you should not do this
+                  unless instructed to.
+                </p>
+                <Button
+                  color="danger"
+                  size="wide"
+                  onClick={() => settingsMutations.reloadEventsFile.mutate()}
+                >
+                  Reload Events File
+                </Button>
+                <Button color="danger" size="wide" onClick={() => setRecreateOpen(true)}>
+                  Recreate Database
+                </Button>
+                <Button color="danger" size="wide" onClick={() => setRecoverOpen(true)}>
+                  Recover Data from CSV File
+                </Button>
+              </Stack>
+            </VerticalButtonGroup>
+          </div>
 
-          <VerticalButtonGroup label="App Settings">
-            <Button color="danger" onClick={() => setResetOpen(true)} size="wide">
-              Reset App Settings
-            </Button>
-          </VerticalButtonGroup>
+          <div className="border-t border-component-strong pt-4">
+            <VerticalButtonGroup label="App Settings">
+              <Button color="danger" onClick={() => setResetOpen(true)} size="wide">
+                Reset App Settings
+              </Button>
+            </VerticalButtonGroup>
+          </div>
         </Stack>
       </Stack>
 

--- a/src/renderer/src/features/SettingsPage/hooks/useSettingsMutations.tsx
+++ b/src/renderer/src/features/SettingsPage/hooks/useSettingsMutations.tsx
@@ -6,21 +6,24 @@ import * as loggerHooks from "~/hooks/ipc/useLogger";
 export function useSettingsMutations() {
   const { createToast } = useToasts();
 
-  const importAthletesFile = useBasicIpcCall("load-athletes-file", {
-    preToast: "Loading Athletes file"
-  });
-
-  const importStationsFile = useBasicIpcCall("load-stations-file", {
-    preToast: "Loading Stations file",
-    invalidateQueryKeys: [["opensplittime-event-group-configured"]]
-  });
-
   const importDropsFile = useBasicIpcCall("load-drops-file", {
     preToast: "Loading Drops file"
   });
 
   const importRunnerCSVFile = useBasicIpcCall("import-runners-file", {
     preToast: "Loading Runners file"
+  });
+
+  const reloadEventsFile = useBasicIpcCall("reload-events-file", {
+    preToast: "Reloading Events file",
+    invalidateQueryKeys: [
+      ["opensplittime-event-group-configured"],
+      ["runners-table"],
+      ["stations-list"],
+      ["athletes-table"],
+      ["stats-table"],
+      ["station"]
+    ]
   });
 
   const initializeDatabaseMutation = useBasicIpcCall("initialize-database");
@@ -56,10 +59,9 @@ export function useSettingsMutations() {
     resetAppSettings,
     initializeRfid,
     disconnectRfid,
-    importAthletesFile,
-    importStationsFile,
     importDropsFile,
     importRunnerCSVFile,
+    reloadEventsFile,
     reinitializeDatabase
   };
 }


### PR DESCRIPTION
## Summary
Implemented a developer utility to reload event zip archive files, added the "Reload Events File" button to the Developer Tools panel on the Settings page while removing obsolete import buttons, updated the Settings page panel layout and visual dividers, and updated documentation accordingly.

## Changes
- **Backend**: Added \eloadEventArchiveFile\ in main process and \eload-events-file\ IPC handler.
- **Settings Page**: Added \Reload Events File\ button under Developer Tools and removed obsolete \Load Stations File\ and \Load Athletes File\ buttons.
- **Settings Page Layout**: Swapped visual positions of User Settings and RFID Configuration panels and added top border dividers between stacked panels.
- **Documentation**: Updated \README.md\, \get-started.md\, and \vent-archive-format.md\ to document the new reloader, Settings page workflow, and updated layout.

## Testing
- Not applicable: Code changes already validated during implementation step.