### PR TITLE
fix(logger): do not let logging crash the app or block the operator

### DIFF
--- a/src/main/lib/logger.ts
+++ b/src/main/lib/logger.ts
@@ -21,8 +21,18 @@ export function initialize() {
   log.initialize();
   log.transports.file.resolvePathFn = () =>
     path.join(app.getPath("documents"), app.name, `.logs/${now}-main.log`);
-  log.errorHandler.startCatching();
+  // showDialog defaults to true; an operator mid-event should not have to
+  // dismiss a stack trace.
+  log.errorHandler.startCatching({ showDialog: false });
   log.transports.console.format = "[{iso}] [{level}] [{processType}] {text}";
+
+  // A closed stdout raises EPIPE, which the handler above logs, which writes
+  // again, which raises EPIPE again. Swallow it so logging cannot kill the app.
+  for (const stream of [process.stdout, process.stderr]) {
+    stream.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code !== "EPIPE") throw err;
+    });
+  }
   // Keep the app on a single console transport and let electron-log handle file output.
   // This avoids duplicates like the same message being emitted twice to the terminal.
   console.log = (...args: unknown[]) => {


### PR DESCRIPTION
## Summary

Split out of #294 at review request — unrelated to the Linux packaging work.

Two small logging fixes:

**EPIPE no longer takes the app down.** `console.*` is routed through electron-log's console transport, which writes to stdout. If that stream is gone — a shell whose pipe has closed, or a service with no stdout — the write raises `EPIPE`. Nothing handled it, so the error handler logged it, which wrote again, which raised `EPIPE` again. Now ignored on stdout and stderr.

**No modal stack traces.** `startCatching` defaults `showDialog` to true, which puts a raw stack trace in a modal in front of whoever is running the station. Now passed `false`; uncaught errors still reach the log.

## Testing

Existing behaviour is unchanged in normal use — logging still goes to the console and the log file. The EPIPE path was reproduced by piping the app's output to a command that exits early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)