### PR TITLE
fix(rfid): close websocket on app shutdown

### DIFF
--- a/src/main/api/rfid-processor.ts
+++ b/src/main/api/rfid-processor.ts
@@ -93,6 +93,10 @@ export async function DisconnectRFIDReader(): Promise<string> {
   }
 }
 
+export function CloseRFIDWebSocket(): void {
+  rfidController?.closeWebSocket();
+}
+
 export function RecoverRFIDReader(): void {
   rfidController?.recover();
 }

--- a/src/main/api/rfid/interfaces/IRfid-controller.ts
+++ b/src/main/api/rfid/interfaces/IRfid-controller.ts
@@ -8,6 +8,7 @@ export interface IRfidController {
   initialize(settings: RfidSettings): Promise<void>;
   connect(): void;
   disconnect(): Promise<void>;
+  closeWebSocket(): void;
   recover(): void;
   startRFID(): Promise<void>;
   stopRFID(): Promise<void>;

--- a/src/main/api/rfid/zebra-fxr90/zebra-fxr90-controller.ts
+++ b/src/main/api/rfid/zebra-fxr90/zebra-fxr90-controller.ts
@@ -80,6 +80,13 @@ export class ZebraFxr90Controller implements IRfidController {
     await this.restClient?.stop();
   }
 
+  public closeWebSocket(): void {
+    this.manuallyDisconnected = true;
+    this.stopHealthChecks();
+    this.clearReconnectTimer();
+    this.rfidProcessor?.disconnect();
+  }
+
   public recover(): void {
     this.manuallyDisconnected = false;
     this.scanning = false;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@ import { join } from "path";
 import { electronApp, is, optimizer } from "@electron-toolkit/utils";
 import { BrowserWindow, Event, Menu, app, dialog, powerMonitor, shell } from "electron";
 import iconLinux from "$resources/iconLinux.png?asset";
-import { DisconnectRFIDReader, RecoverRFIDReader } from "./api/rfid-processor";
+import { CloseRFIDWebSocket, RecoverRFIDReader } from "./api/rfid-processor";
 import {
   adoptLegacyDatabaseIfPresent,
   getDatabaseConnection,
@@ -147,7 +147,7 @@ async function initializeApp(): Promise<void> {
   app.on("activate", function () {
     app.on("window-all-closed", () => {
       if (process.platform !== "darwin") {
-        DisconnectRFIDReader();
+        CloseRFIDWebSocket();
         app.quit();
       }
       shutdown();
@@ -197,7 +197,7 @@ app.on("activate", () => {
 //Window Close Handler
 app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
-    DisconnectRFIDReader();
+    CloseRFIDWebSocket();
     app.quit();
   }
   shutdown();


### PR DESCRIPTION
- Added CloseRFIDWebSocket() for application shutdown.
- App closing now closes the RFID WebSocket without calling PUT /cloud/stop.
- Intentional user disconnect still calls DisconnectRFIDReader(), which stops the reader first.
- Shutdown cleanup stops health checks and cancels reconnect timers.
- Added the new method to the RFID controller interface.-
- Updated Electron app-close handlers to use WebSocket-only cleanup.
- Verified with Node typecheck and scoped ESLint.